### PR TITLE
fix(schemas): allow x-* extension properties in runtime schema validators

### DIFF
--- a/docs/schemas/runtime/flavour.schema.yaml
+++ b/docs/schemas/runtime/flavour.schema.yaml
@@ -45,6 +45,9 @@ required:
   - metadata
   - spec
 additionalProperties: false
+patternProperties:
+  "^x-":
+    description: "Extension properties (UI metadata, canvas state, etc.) — ignored by the runtime."
 
 properties:
   apiVersion:

--- a/docs/schemas/runtime/overlay.schema.yaml
+++ b/docs/schemas/runtime/overlay.schema.yaml
@@ -16,6 +16,9 @@ required:
   - metadata
   - spec
 additionalProperties: false
+patternProperties:
+  "^x-":
+    description: "Extension properties (UI metadata, canvas state, etc.) — ignored by the runtime."
 properties:
   apiVersion:
     type: string

--- a/docs/schemas/runtime/tool.schema.yaml
+++ b/docs/schemas/runtime/tool.schema.yaml
@@ -18,6 +18,9 @@ required:
   - metadata
   - spec
 additionalProperties: false
+patternProperties:
+  "^x-":
+    description: "Extension properties (UI metadata, canvas state, etc.) — ignored by the runtime."
 properties:
 
   apiVersion:


### PR DESCRIPTION
Add patternProperties to allow arbitrary x-* fields (e.g., x-canvas-state,
x-ui-metadata) in schema definitions. These fields are used by UI tools and
canvas renderers but are safely ignored by the runtime.

Fixes schema validation rejecting valid x-* extension fields that the runtime
accepts.

Files:
- docs/schemas/runtime/flavour.schema.yaml
- docs/schemas/runtime/overlay.schema.yaml
- docs/schemas/runtime/tool.schema.yaml

Each change: added patternProperties with regex pattern '^x-' and description
of extension properties purpose.
