### PR TITLE
feat(observability,plots): enrich context provenance and clean up visualization

### DIFF
--- a/lab/components/bench/src/mas/lab/plots/assets/multilevel.html
+++ b/lab/components/bench/src/mas/lab/plots/assets/multilevel.html
@@ -81,23 +81,9 @@ body{font-family:'Inter',ui-sans-serif,sans-serif;background:#0f172a;color:#e2e8
 .facet-item.facet-highlight .facet-content pre{border:1px solid rgba(249,115,22,.35)}
 .facet-new{font-size:.58rem;font-weight:700;letter-spacing:.05em;text-transform:uppercase;
   padding:1px 5px;border-radius:3px;background:#9a3412;color:#ffedd5;white-space:nowrap}
-/* Card layout with pie chart */
-.cpr-body{display:flex;gap:1rem;align-items:flex-start}
-.cpr-facets{flex:1;min-width:0}
-.cpr-right{flex-shrink:0;display:flex;flex-direction:column;align-items:center;gap:.4rem;min-width:140px}
-.cpr-pie-label{font-size:.65rem;color:#64748b;text-align:center}
-.cpr-pie-value{font-size:.85rem;font-weight:700;color:#e2e8f0}
-/* Pie/donut chart */
-.cpr-pie{position:relative;width:120px;height:120px}
-.cpr-pie svg{width:100%;height:100%}
-.cpr-pie-center{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);
-  text-align:center;pointer-events:none}
-.cpr-pie-center .pct{font-size:1.1rem;font-weight:700;color:#e2e8f0;line-height:1.2}
-.cpr-pie-center .pct-label{font-size:.6rem;color:#64748b}
-/* Pie legend */
-.pie-legend{display:flex;flex-wrap:wrap;gap:.3rem .7rem;margin-top:.3rem}
-.pie-legend-item{display:flex;align-items:center;gap:.25rem;font-size:.65rem;color:#94a3b8}
-.pie-legend-swatch{width:8px;height:8px;border-radius:2px}
+/* Card layout — moodbar + breakdown stacked vertically, facets full-width below */
+.cpr-body{display:flex;flex-direction:column;gap:.6rem}
+.cpr-facets{width:100%;min-width:0}
 /* Facet list */
 .facet-list{display:flex;flex-direction:column;gap:0}
 .facet-item{border-left:3px solid var(--fc,#64748b);background:rgba(255,255,255,.02);
@@ -971,7 +957,7 @@ function renderMoodbar(parts, showLabels) {
   return html;
 }
 
-function renderPieChart(parts, model) {
+function renderCategoryBreakdown(parts) {
   const bycat = {};
   let totalTok = 0;
   parts.forEach(p => {
@@ -979,49 +965,15 @@ function renderPieChart(parts, model) {
     bycat[c] = (bycat[c]||0) + (p.tokens||0);
     totalTok += (p.tokens||0);
   });
-  const ctxWin = getCtxWindow(model);
-  const usagePct = ctxWin > 0 ? Math.min(100, totalTok/ctxWin*100) : 0;
-
-  // SVG gauge (single arc showing context window usage)
-  const cx = 60, cy = 65;
-  const R = 48, strokeW = 12;
-  // Arc spans 240° (from 150° to 390° i.e. bottom-left to bottom-right)
-  const arcStart = 150 * Math.PI / 180;
-  const arcSpan  = 240 * Math.PI / 180;
-  const arcEnd   = arcStart + arcSpan;
-  // Background track
-  const bx1 = cx + R*Math.cos(arcStart), by1 = cy + R*Math.sin(arcStart);
-  const bx2 = cx + R*Math.cos(arcEnd),   by2 = cy + R*Math.sin(arcEnd);
-  let svg = `<path d="M${bx1},${by1} A${R},${R} 0 1 1 ${bx2},${by2}" fill="none" stroke="#1e293b" stroke-width="${strokeW}" stroke-linecap="round"/>`;
-  // Filled arc (usage)
-  if (usagePct > 0) {
-    const frac = Math.min(1, usagePct / 100);
-    const fillEnd = arcStart + frac * arcSpan;
-    const fx2 = cx + R*Math.cos(fillEnd), fy2 = cy + R*Math.sin(fillEnd);
-    const large = frac > 0.5 ? 1 : 0;
-    // Color: green < 50%, yellow < 80%, red >= 80%
-    const gaugeCol = usagePct >= 80 ? '#ef4444' : usagePct >= 50 ? '#eab308' : '#22d3ee';
-    svg += `<path d="M${bx1},${by1} A${R},${R} 0 ${large} 1 ${fx2},${fy2}" fill="none" stroke="${gaugeCol}" stroke-width="${strokeW}" stroke-linecap="round"/>`;
-  }
-
-  let html = `<div class="cpr-pie"><svg viewBox="0 0 120 120">${svg}</svg>`;
-  html += '<div class="cpr-pie-center">';
-  html += `<div class="pct">${totalTok} tok</div>`;
-  if (ctxWin > 0) {
-    html += `<div class="pct-label">${usagePct.toFixed(1)}% of ${(ctxWin/1000).toFixed(0)}k</div>`;
-  }
-  html += '</div></div>';
-
-  // Legend (category breakdown as compact badges — moodbar already shows distribution)
-  html += '<div class="pie-legend">';
+  
   const cats = Object.entries(bycat).sort((a,b)=>b[1]-a[1]);
-  cats.forEach(([cat, tok]) => {
-    const col = (parts.find(p=>(p._uiCatLabel||CPR_CAT_LABELS[p.category]||p.category||'Context')===cat)?._uiColor) || '#64748b';
+  const breakdown = cats.map(([cat, tok]) => {
     const pct = ((tok/(totalTok||1))*100).toFixed(0);
-    html += `<div class="pie-legend-item"><div class="pie-legend-swatch" style="background:${col}"></div>${cat} ${pct}%</div>`;
-  });
-  html += '</div>';
-  return html;
+    const col = (parts.find(p=>(p._uiCatLabel||CPR_CAT_LABELS[p.category]||p.category||'Context')===cat)?._uiColor) || '#64748b';
+    return `<span style="color:#e2e8f0"><span style="display:inline-block;width:8px;height:8px;background:${col};border-radius:2px;margin-right:4px;vertical-align:middle"></span>${cat}</span> <span style="color:#94a3b8">${pct}% (${tok}t)</span>`;
+  }).join(' <span style="color:#334155">·</span> ');
+  
+  return `<div style="font-size:.72rem;color:#cbd5e1;margin-top:.3rem">${breakdown}</div>`;
 }
 
 function renderFacetList(parts) {
@@ -1120,25 +1072,19 @@ function renderFacetList(parts) {
 function renderCprCard(parts, model, hoverOut, timeLine) {
   const totalTok = parts.reduce((s,p)=>s+(p.tokens||0), 0);
   const nParts = parts.length;
-  const byCat = {};
-  parts.forEach(p => {
-    const c = p._uiCatLabel || CPR_CAT_LABELS[p.category] || p.category || 'Context';
-    byCat[c] = (byCat[c]||0)+1;
-  });
-  const catSummary = Object.entries(byCat).map(([c,n])=>`${c} ×${n}`).join(', ');
 
   let html = '<div class="cpr-card">';
   // Time + summary
   if (timeLine) html += `<div style="color:#94a3b8;font-size:.72rem;margin-bottom:.4rem">${escH(timeLine)}</div>`;
-  html += `<div class="cpr-summary">${nParts} parts · ${totalTok} tokens · ${catSummary}`;
+  html += `<div class="cpr-summary">${nParts} parts · ${totalTok} tokens`;
   if (model) html += ` · model: ${escH(model)}`;
   html += '</div>';
-  // Moodbar (sticky wrapper so it stays visible while scrolling facets)
-  html += '<div class="moodbar-sticky">' + renderMoodbar(parts, true) + '</div>';
-  // Body: facets + pie
+  // Moodbar + category breakdown
+  html += renderMoodbar(parts, true);
+  html += renderCategoryBreakdown(parts);
+  // Facets full-width
   html += '<div class="cpr-body">';
   html += '<div class="cpr-facets">' + renderFacetList(parts) + '</div>';
-  html += '<div class="cpr-right">' + renderPieChart(parts, model) + '</div>';
   html += '</div>';
   // Output — only when it isn't already shown verbatim as one of the facet
   // cards above (e.g. via _buildGenericTransitionParts' llm/output+call/output

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/__init__.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/__init__.py
@@ -31,6 +31,7 @@ Public entry point: ``plot_multilevel_trajectory(trace, fmt, ...)``
 from mas.lab.plots.multilevel_trajectory.annotations import (
     _collect_annotations,
     _collect_context_provenance,
+    _derive_context_semantics,
     _format_cpr_hover,
     _source_category,
     _stagger_coinc_processing_calls,

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/annotations.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/annotations.py
@@ -167,25 +167,101 @@ def _source_category(source: str, mechanism: str = "inject") -> str:
 _SECTION_ORDINAL_RE = re.compile(r"assembled/(\d+)/")
 
 
+_ROLE_SEMANTICS = {
+    "system": dict(cause="system prompt", causeType="system",
+                   trigger="system_initialization", actor="system",
+                   via="system_configuration", cause_detail="system prompt"),
+    "user": dict(cause="user turn", causeType="user_provided",
+                 trigger="user_input", actor="user",
+                 via="user_provided", cause_detail="user turn"),
+    "assistant": dict(cause="LLM response", causeType="llm_decision",
+                      trigger="llm_response", actor="llm",
+                      via="llm_generated", cause_detail="assistant turn"),
+    "tool": dict(cause="tool result", causeType="tool_result",
+                 trigger="tool_execution", actor="tool",
+                 via="tool_provided", cause_detail="tool execution result"),
+}
+
+_ROLE_SEMANTICS_ASSISTANT_TOOL_CALL = dict(
+    cause="LLM tool-call decision", causeType="llm_decision",
+    trigger="llm_tool_call", actor="llm",
+    via="llm_generated", cause_detail="LLM tool-call decision")
+
+_ROLE_SEMANTICS_TOOL_DELEGATION = dict(
+    cause="delegation result", causeType="delegated",
+    trigger="delegation_result", actor="delegated_agent",
+    via="delegation", cause_detail="delegation result")
+
+_UNKNOWN_SEMANTICS = dict(cause="?", causeType="unknown",
+                          trigger="context_addition", actor="?",
+                          via="injected", cause_detail="context addition")
+
+
+def _detect_delegation(tool_call_id: str, content: str) -> bool:
+    """Check if tool result is from delegation."""
+    return "delegate" in content.lower() or "delegat" in tool_call_id.lower()
+
+
+def _derive_context_semantics(
+    role: str, source: str = "", *, tool_call_id: str = "", content: str = ""
+) -> dict:
+    """Derive semantic fields from role, source, tool_call_id, and content.
+
+    This implements the normalized data model where events.jsonl carries only
+    source facts (role, source, IDs) and semantics are derived at query time.
+    The derivation rule is deterministic: f(role, source, ...) → semantics dict.
+
+    Args:
+        role: OpenAI message role (system, user, assistant, tool)
+        source: Provenance source path (e.g., "context/system", "assembled/user")
+        tool_call_id: Tool call identifier (for delegation detection)
+        content: Message content (for delegation detection)
+
+    Returns:
+        dict with keys: cause, causeType, trigger, actor, via, cause_detail
+    """
+    # Normalize inputs
+    r = str(role or "?").strip().lower() if role else ""
+    s = str(source or "").strip().lower() if source else ""
+
+    # Lookup base semantics for role
+    semantics = _ROLE_SEMANTICS.get(r)
+    if semantics is None:
+        return _UNKNOWN_SEMANTICS.copy()
+
+    # Apply role-specific overrides for special cases
+    if r == "assistant" and "tool_call" in s:
+        return _ROLE_SEMANTICS_ASSISTANT_TOOL_CALL.copy()
+    elif r == "tool" and _detect_delegation(tool_call_id, content):
+        return _ROLE_SEMANTICS_TOOL_DELEGATION.copy()
+
+    return semantics.copy()
+
+
 def _collect_context_provenance(
     events:  list[dict],
     records: list[dict],
 ) -> dict[str, list[dict]]:
-    """Return ``call_id → [cpr_event, …]`` for L4 context provenance hover enrichment.
+    """Return ``call_id → [context_part_event, …]`` for context provenance hover enrichment.
+
+    This function collects ``context_part_contributed`` events (the authoritative
+    source for per-chunk provenance information) and enriches them for visualization.
+
+    Context Metadata Model:
+    - **Normalized storage**: events.jsonl carries only source facts (role, source, IDs)
+    - **Derived semantics**: actor, trigger, via are computed deterministically at query time
+    - **Deterministic rule**: f(role, source) → {actor, trigger, via}
+    - **Example**: role="assistant" + source="assembled/tool_call" → actor="llm", trigger="llm_tool_call"
 
     ``context_part_contributed`` events are matched to LLM call records by a
-    direct, real id match on ``llm_call_id`` — the runtime now resolves this
-    to the SAME call_id the LLM call's own llm_call_start/end use (see
-    ObservabilityOperator.record_context_assembled's op="LLM_CALL" threading
-    and _resolve_transition_ids' CONTEXT_ASSEMBLED branch), never a synthetic
-    placeholder needing timestamp-proximity reconstruction.
+    direct, real id match on ``llm_call_id`` — the runtime resolves this to the
+    SAME call_id the LLM call's own llm_call_start/end use via runtime-determined
+    resolution.
 
     ``context_part_contributed`` is the authoritative source for per-chunk
     PROVENANCE (source, mechanism, retention decision, section ordinal,
-    token estimate) — but it never carries the full chunk text, only a
-    ``content_preview`` hard-truncated to 120 chars (verified: 0/72 real
-    events in a production trace carry a ``content`` key at all). The
-    sibling ``context_assembled`` event for the SAME call_id/llm_call_id is
+    token estimate), carrying a ``content_preview`` hard-truncated to 120 chars. The sibling
+    ``context_assembled`` event for the SAME call_id/llm_call_id is
     the authoritative source for the assembled context's full, non-truncated
     ``messages`` — so each part's preview is upgraded here to the matching
     full message text (matched by the part's ``section_id`` ordinal, e.g.

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/constants.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/constants.py
@@ -104,6 +104,19 @@ _TS_TOL: float = 0.05
 # the session's true final timestamp past the pre-stagger t_max.
 _STAGGER_DUR: float = 0.001
 
+# Processing type constants — standardized names for execution flow patterns
+PROCESSING_TYPE_WAIT_STATE = "wait_state"
+PROCESSING_TYPE_CONTEXT_ASSEMBLY = "context_assembly"
+PROCESSING_TYPE_PARALLEL_GROUP = "parallel_group"
+PROCESSING_TYPE_PARALLEL_FORK = "parallel_fork"
+
+# Processing name constants — specific names for processing operations
+PROCESSING_NAME_PARALLEL_FORK = "parallel fork"
+PROCESSING_NAME_CONTEXT_ASSEMBLY = "context assembly"
+
+# Wait scope constants — categorizes types of waiting/delegation
+WAIT_SCOPE_DELEGATION = "delegation"
+
 # Icons for instant (≈0-duration) call types — rendered on top of state boxes.
 _INSTANT_ICON: dict[str, str] = {
     "ProcessingCall": "⚙",

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/dag.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/dag.py
@@ -17,6 +17,7 @@ from mas.lab.plots.multilevel_trajectory.annotations import (
     _collect_llm_tool_decisions,
     _format_cpr_hover,
     _source_category,
+    _derive_context_semantics,
     _stagger_coinc_processing_calls,
 )
 from mas.lab.plots.multilevel_trajectory.constants import (
@@ -24,6 +25,13 @@ from mas.lab.plots.multilevel_trajectory.constants import (
     _STAGGER_DUR,
     _TS_TOL,
     TYPE_LABEL,
+    PROCESSING_TYPE_WAIT_STATE,
+    PROCESSING_TYPE_CONTEXT_ASSEMBLY,
+    PROCESSING_TYPE_PARALLEL_GROUP,
+    PROCESSING_TYPE_PARALLEL_FORK,
+    PROCESSING_NAME_PARALLEL_FORK,
+    PROCESSING_NAME_CONTEXT_ASSEMBLY,
+    WAIT_SCOPE_DELEGATION,
 )
 from mas.lab.plots.multilevel_trajectory.governance import (
     _collect_blocked_actions,
@@ -232,7 +240,7 @@ def _build_dag(
         _fidx = _crec.get("_agent_fragment_idx")
         if _fidx is None:
             continue
-        if _crec.get("_delegation_marker") or str(_crec.get("processing_type") or "") == "wait_state":
+        if _crec.get("_delegation_marker") or str(_crec.get("processing_type") or "") == PROCESSING_TYPE_WAIT_STATE:
             continue
         _cend = _crec.get("end_ts", 0.0)
         if _cend > _frag_end_ts.get(_fidx, float("-inf")):
@@ -277,7 +285,7 @@ def _build_dag(
     # S9/R1-vertical-misalignment symptom this whole reconciliation exists
     # to fix. Only ever advances (never shrinks), same cap as above.
     for _ci, _crec in enumerate(call_sequence):
-        if str(_crec.get("processing_type") or "") != "wait_state":
+        if str(_crec.get("processing_type") or "") != PROCESSING_TYPE_WAIT_STATE:
             continue
         if str(_crec.get("wait_role") or "").strip().upper() != "RESUME":
             continue
@@ -568,10 +576,12 @@ def _build_dag(
         if _missing_telemetry:
             _missing_note = f"[missing telemetry: {', '.join(_missing_telemetry)}]"
             base_in = (_missing_note + ("\n" + base_in if base_in else "")).strip()
-        # Build structured CPR data for rich JS rendering.
+        # Build structured context provenance data for rich JS rendering.
         # For ProcessingCall records that carry their own ``segments`` (per-actor
-        # spans emitted by ObservabilityPlugin), build CPR from those segments
-        # directly instead of from the cpr_map (which maps LLMCall call_ids).
+        # spans emitted by ObservabilityPlugin), build provenance from those segments
+        # directly instead of from the provenance_map (which maps LLMCall call_ids).
+        # Semantic fields (actor, trigger, via) are derived from (role, source) using
+        # _derive_context_semantics() — the normalized data model principle.
         _rec_segments = rec.get("segments") if (show_provenance and ct == "ProcessingCall") else None
         if _rec_segments:
             _cpr_structured: list[dict] = []
@@ -579,24 +589,26 @@ def _build_dag(
                 _prov = _s.get("provenance") or {}
                 _psrc = _s.get("source", "?")
                 _pmech = _prov.get("mechanism", "inject")
+                _role = _s.get("role") or _prov.get("role") or ""
+                _role_defs = _derive_context_semantics(_role, _psrc)
                 _entry: dict = {
                     "source": _psrc,
                     "category": _source_category(_psrc, _pmech),
                     "mechanism": _pmech,
                     "retrieval": _prov.get("retrieval", ""),
                     "decision": _prov.get("decision", ""),
-                    "causeType": _prov.get("cause_type", "deterministic"),
-                    "cause": _prov.get("cause", "?"),
+                    "causeType": _prov.get("cause_type") or _role_defs["causeType"],
+                    "cause": _prov.get("cause") or _role_defs["cause"],
                     "tokens": _s.get("tokens") or 0,
                     "retained": True,
                     "placement": _s.get("placement", ""),
                     "content": _s.get("content", ""),
                     "sectionId": _s.get("section_id", ""),
-                    "sourceType": _prov.get("source_type", ""),
+                    "sourceType": _prov.get("source_type") or _s.get("role") or "",
                     "sourceId": _prov.get("source_id", ""),
-                    "trigger": _prov.get("trigger", ""),
-                    "actor": _prov.get("actor", ""),
-                    "via": _prov.get("via", ""),
+                    "trigger": _prov.get("trigger") or _role_defs["trigger"],
+                    "actor": _prov.get("actor") or _role_defs["actor"],
+                    "via": _prov.get("via") or _role_defs["via"],
                 }
                 _ann = _prov.get("annotations")
                 if _ann:
@@ -611,31 +623,34 @@ def _build_dag(
                 if _chain:
                     _entry["chain"] = _chain
                 _cpr_structured.append(_entry)
-            _cpr_raw = []  # no legacy CPR hover for per-actor spans
+            _cpr_raw = []  # provenance collected at call level only
         else:
             _cpr_raw = cpr_map.get(_cid, [])
             _cpr_structured = []
             for _p in _cpr_raw:
                 _psrc = _p.get("source", "?")
                 _pmech = _p.get("mechanism", "inject")
+                _role = _p.get("role") or ""
+                # Derive semantic fields from role + source (normalized data model)
+                _role_defs = _derive_context_semantics(_role, _psrc)
                 _entry: dict = {
                     "source": _psrc,
                     "category": _source_category(_psrc, _pmech),
                     "mechanism": _pmech,
                     "retrieval": _p.get("retrieval", ""),
                     "decision": _p.get("decision", ""),
-                    "causeType": _p.get("cause_type", "deterministic"),
-                    "cause": _p.get("cause", "?"),
+                    "causeType": _p.get("cause_type") or _role_defs["causeType"],
+                    "cause": _p.get("cause") or _role_defs["cause"],
                     "tokens": _p.get("token_estimate", 0),
                     "retained": _p.get("retained", True),
                     "placement": _p.get("placement", ""),
                     "content": _p.get("content") or _p.get("content_preview") or "",
                     "sectionId": _p.get("section_id", ""),
-                    "sourceType": _p.get("source_type", ""),
+                    "sourceType": _p.get("source_type") or _p.get("role") or "",
                     "sourceId": _p.get("source_id", ""),
-                    "trigger": _p.get("trigger", ""),
-                    "actor": _p.get("actor", ""),
-                    "via": _p.get("via", ""),
+                    "trigger": _p.get("trigger") or _role_defs["trigger"],
+                    "actor": _p.get("actor") or _role_defs["actor"],
+                    "via": _p.get("via") or _role_defs["via"],
                 }
                 _ann = _p.get("annotations")
                 if _ann:
@@ -703,10 +718,10 @@ def _build_dag(
             connector_only=(
                 ct == "ProcessingCall"
                 and (
-                    str(rec.get("processing_type") or "") == "wait_state"
+                    str(rec.get("processing_type") or "") == PROCESSING_TYPE_WAIT_STATE
                     or (
-                        str(rec.get("processing_type") or "") == "parallel_group"
-                        and str(rec.get("processing_name") or "").strip().lower() == "parallel fork"
+                        str(rec.get("processing_type") or "") == PROCESSING_TYPE_PARALLEL_GROUP
+                        and str(rec.get("processing_name") or "").strip().lower() == PROCESSING_NAME_PARALLEL_FORK
                     )
                 )
             ),
@@ -1074,7 +1089,7 @@ def _build_dag(
         for _r in call_sequence:
             if str(_r.get("call_type") or "") != "ProcessingCall":
                 continue
-            if str(_r.get("processing_type") or "") != "wait_state":
+            if str(_r.get("processing_type") or "") != PROCESSING_TYPE_WAIT_STATE:
                 continue
             _wid = str(_r.get("wait_link_id") or "").strip()
             _role = str(_r.get("wait_role") or "").strip().upper()
@@ -1160,7 +1175,7 @@ def _build_dag(
             _w, _r = _pair.get("WAIT"), _pair.get("RESUME")
             if not _w or not _r:
                 continue
-            if str(_w.get("wait_scope") or "").strip().lower() != "delegation":
+            if str(_w.get("wait_scope") or "").strip().lower() != WAIT_SCOPE_DELEGATION:
                 continue
             _wait_intervals[_wid] = (
                 float(_w.get("start_ts") or 0.0),
@@ -1263,7 +1278,7 @@ def _build_dag(
                 "isContextCrossing": True,
                 "blocking": {
                     "kind": "TOOL_CALL",
-                    "toolType": "DELEGATION" if _wait_scope == "delegation" else "TOOL_CALL",
+                    "toolType": "DELEGATION" if _wait_scope == WAIT_SCOPE_DELEGATION else "TOOL_CALL",
                     "toolName": _blocking_tool_name,
                     "toolCallId": _blocking_tool_call_id,
                     "context": _blocking_context,
@@ -1347,7 +1362,7 @@ def _build_dag(
             # timestamp exists as a concrete state in-lane so Wn/Rn placement
             # stays stable. For regular calls, preserve the historical behavior
             # to avoid inserting synthetic connector transitions.
-            if ct_j == "ProcessingCall" and str(crec.get("processing_type") or "") == "wait_state":
+            if ct_j == "ProcessingCall" and str(crec.get("processing_type") or "") == PROCESSING_TYPE_WAIT_STATE:
                 if str(crec.get("wait_role") or "").strip().upper() == "RESUME":
                     # A RESUME record's own ts and the real delegated reply's
                     # own completion ts (the preceding state, carrying the
@@ -1574,8 +1589,11 @@ def _build_dag(
                         "mechanism": "inject",
                         "retrieval": "",
                         "decision": "",
-                        "causeType": "deterministic",
-                        "cause": "assistant",
+                        "causeType": "llm_decision",
+                        "cause": "LLM tool-call decision",
+                        "trigger": "llm_tool_call",
+                        "actor": "llm",
+                        "via": "llm_generated",
                         "tokens": max(1, len(_own_llm_out) // 4),
                         "retained": True,
                         "placement": "assembled/2/assistant",
@@ -1583,7 +1601,7 @@ def _build_dag(
                     }
                     st_end.cpr_data = list(st_start.cpr_data) + [_own_entry]
                     st_end.model = st_start.model
-            if ct_j == "ProcessingCall" and str(crec.get("processing_type") or "") == "wait_state":
+            if ct_j == "ProcessingCall" and str(crec.get("processing_type") or "") == PROCESSING_TYPE_WAIT_STATE:
                 _wid = str(crec.get("wait_link_id") or f"wait-{crec.get('call_id', j)}")
                 _role = str(crec.get("wait_role") or "").strip().upper()
                 _note = str(crec.get("wait_note") or "").strip()
@@ -1709,8 +1727,11 @@ def _build_dag(
                                 "mechanism": "append",
                                 "retrieval": "",
                                 "decision": "",
-                                "causeType": "deterministic",
-                                "cause": "tool",
+                                "causeType": "tool_result",
+                                "cause": "tool execution result",
+                                "trigger": "tool_execution",
+                                "actor": "tool",
+                                "via": "tool_provided",
                                 "tokens": max(1, len(_result_output) // 4),
                                 "retained": True,
                                 "placement": "tool/output",
@@ -2116,8 +2137,11 @@ def _build_dag(
                             "mechanism": "inject",
                             "retrieval": "",
                             "decision": "",
-                            "causeType": "deterministic",
-                            "cause": "delegation",
+                            "causeType": "delegated",
+                            "cause": "delegation task",
+                            "trigger": "delegation_dispatch",
+                            "actor": "moderator",
+                            "via": "delegation",
                             "tokens": max(1, len(_delegate_input) // 4),
                             "retained": True,
                             "placement": "assembled/user",

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/records.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/records.py
@@ -14,7 +14,14 @@ from mas.lab.plots.multilevel_trajectory.constants import (
     _KIND_BASE_TO_TYPE,
     _PROC_TYPE_LABEL,
     _TS_TOL,
+    PROCESSING_NAME_CONTEXT_ASSEMBLY,
 )
+from mas.lab.plots.multilevel_trajectory.annotations import _derive_context_semantics
+
+
+def _normalized_str(s: Any, default: str = "?") -> str:
+    """Normalize a value to lowercase string, with default fallback."""
+    return str(s or default).strip().lower() if s else default
 
 
 def _normalize_context_messages(messages: Any) -> list[dict[str, str]]:
@@ -24,7 +31,7 @@ def _normalize_context_messages(messages: Any) -> list[dict[str, str]]:
     for m in messages:
         if not isinstance(m, dict):
             continue
-        role = str(m.get("role") or "?").strip().lower()
+        role = _normalized_str(m.get("role"))
         content = m.get("content") or ""
         if isinstance(content, list):
             content = " ".join(
@@ -37,29 +44,97 @@ def _normalize_context_messages(messages: Any) -> list[dict[str, str]]:
     return out
 
 
-def _context_parts_from_messages(messages: list[dict[str, str]]) -> list[dict[str, Any]]:
+def _context_parts_from_messages(
+    messages: list[dict[str, str]],
+    *,
+    prev_messages: list[dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
+    """Build context source records from assembled messages.
+
+    Each part represents a piece of input context: its source, how it was
+    included, what triggered its inclusion, and whether it's new compared to
+    the previous context assembly.
+
+    Attributes tracked for each context piece (what/where/why/when):
+    - What: content (the actual text)
+    - Where: source, sourceType, sourceId, actor, via (where it came from)
+    - Why: decision, cause, trigger, causeType (why it was included)
+    - When: highlight (is it new since last assembly)
+
+    ``prev_messages`` is the input context from the previous LLM call for the
+    same agent. A message is marked ``highlight=True`` (i.e. "new") when its
+    (role, content) pair was not present in the previous context — meaning it
+    was genuinely added since the last time the LLM was called. Tool results
+    (including delegation replies) are marked as new on every appearance; system
+    prompts are marked as new only when they first appear.
+
+    When ``prev_messages`` is ``None`` (first call for this agent), every
+    message is treated as new.
+    """
+    if prev_messages is None:
+        # No history — every piece of context is new.
+        prev_pairs: set[tuple[str, str]] = set()
+        all_new = True
+    else:
+        prev_pairs = {
+            (_normalized_str(m.get("role")), str(m.get("content") or "").strip())
+            for m in prev_messages
+            if str(m.get("content") or "").strip()
+        }
+        all_new = False
+
     parts: list[dict[str, Any]] = []
-    for msg in messages:
-        role = str(msg.get("role") or "?").strip().lower()
+    for msg_idx, msg in enumerate(messages):
+        role = _normalized_str(msg.get("role"))
         content = str(msg.get("content") or "").strip()
         if not content:
             continue
+        is_new = all_new or (role, content) not in prev_pairs
+
+        # Derive semantics from role, source, and content
+        semantics = _derive_context_semantics(
+            role, f"assembled/{role}",
+            tool_call_id=_normalized_str(msg.get("tool_call_id")),
+            content=content
+        )
+        trigger = semantics["trigger"]
+        actor = semantics["actor"]
+        via = semantics["via"]
+        cause_type = semantics["causeType"]
+        cause_detail = semantics["cause_detail"]
+
         parts.append({
+            # What: the context content
+            "content": content,
+            # Where: source tracking
             "source": f"context/{role}",
+            "sourceType": role,
+            "sourceId": f"message_{msg_idx}",
+            "actor": actor,
+            "via": via,
+            # Why: decision tracking
+            "decision": "",  # empty unless specified in event data
+            "cause": cause_detail,
+            "causeType": cause_type,
+            "trigger": trigger,
+            # Category and mechanism (legacy, for compatibility)
             "category": "SYSTEM" if role == "system" else "CONTEXT",
             "mechanism": "inject",
+            # Metadata
             "retrieval": "",
-            "decision": "",
-            "causeType": "deterministic",
-            "cause": "state",
             "tokens": max(1, len(content) // 4),
             "retained": True,
             "placement": f"context/{role}",
-            "content": content,
-            # For context-assembly diffs, treat system prompt injection as
-            # the "new" chunk and keep carried user context unhighlighted.
-            "highlight": role == "system",
+            "sectionId": f"assembled/{msg_idx}/{role}",
+            # Newness flag: True for context pieces added since the previous LLM call
+            # Identifies delegation results, tool calls, and all other new turns
+            "highlight": is_new,
         })
+    # Sort so that newly-added context pieces appear LAST in the list.
+    # This improves readability: existing context is shown first, then the
+    # new additions that caused this context assembly. Uses stable sort to
+    # preserve message order within each group (new vs existing).
+    parts.sort(key=lambda p: p["highlight"])
     return parts
 
 def _build_call_records(events: list[dict]) -> list[dict]:
@@ -141,6 +216,11 @@ def _build_call_records(events: list[dict]) -> list[dict]:
         _args2 = _e.get("arguments")
         if _cid2 not in _tool_args_by_call and isinstance(_args2, dict) and _args2:
             _tool_args_by_call[_cid2] = _args2
+
+    # Per-agent previous context: tracks the assembled context from each agent's
+    # previous LLM call, used to compute diffs for highlighting what actually
+    # changed (newly added context) vs what was carried over.
+    _prev_context_by_agent: dict[str, list[dict[str, str]]] = {}
 
     for ev in sorted(events, key=lambda e: float(e.get("timestamp") or 0)):
         kind      = ev.get("kind", "")
@@ -258,7 +338,13 @@ def _build_call_records(events: list[dict]) -> list[dict]:
                 )
                 if _ctx_msgs:
                     record["context_messages"] = _ctx_msgs
-                    record["context_parts"] = _context_parts_from_messages(_ctx_msgs)
+                    record["context_parts"] = _context_parts_from_messages(
+                        _ctx_msgs,
+                        prev_messages=_prev_context_by_agent.get(agent_id)
+                    )
+                    # Update tracking: this context assembly is now the "previous"
+                    # for the next LLM call from this same agent.
+                    _prev_context_by_agent[agent_id] = _ctx_msgs
             if call_type == "LLMCall" and ev.get("messages"):
                 msgs = ev["messages"]
                 if isinstance(msgs, list) and msgs:
@@ -441,17 +527,24 @@ def _build_call_records(events: list[dict]) -> list[dict]:
                     record["wait_note"] = str(ev.get("wait_note") or "")
                 if not record.get("wait_scope") and ev.get("wait_scope") is not None:
                     record["wait_scope"] = str(ev.get("wait_scope") or "")
-            if call_type == "ProcessingCall" and record.get("processing_name") == "context assembly":
+            if call_type == "ProcessingCall" and record.get("processing_name") == PROCESSING_NAME_CONTEXT_ASSEMBLY:
                 _ctx_msgs = _normalize_context_messages(
                     ev.get("messages")
                     or _ca_messages_by_corr.get((record.get("agent_id"), record.get("correlation_id")))
                 )
                 if _ctx_msgs and not record.get("context_messages"):
                     record["context_messages"] = _ctx_msgs
-                    record["context_parts"] = _context_parts_from_messages(_ctx_msgs)
+                    _agent_id = record.get("agent_id") or ""
+                    record["context_parts"] = _context_parts_from_messages(
+                        _ctx_msgs,
+                        prev_messages=_prev_context_by_agent.get(_agent_id)
+                    )
+                    # Update tracking: this context assembly is now the "previous"
+                    # for the next LLM call from this same agent.
+                    _prev_context_by_agent[_agent_id] = _ctx_msgs
                 if not record.get("context_operation"):
                     record["context_operation"] = str(ev.get("context_operation") or "")
-                if record.get("context_messages") and (not record.get("output") or str(record.get("output", "")).strip() in {"assembled", "context assembly", "context_assembly"}):
+                if record.get("context_messages") and (not record.get("output") or str(record.get("output", "")).strip() in {"assembled", PROCESSING_NAME_CONTEXT_ASSEMBLY, "context_assembly"}):
                     # Keep context assembly as structured CPR only (parts/messages),
                     # not as a synthetic textual diff block.
                     record["output"] = ""
@@ -569,7 +662,7 @@ def _build_call_records(events: list[dict]) -> list[dict]:
     for rec in records:
         if rec.get("call_type") != "ProcessingCall":
             continue
-        if str(rec.get("processing_name") or "").strip().lower() != "context assembly":
+        if str(rec.get("processing_name") or "").strip().lower() != PROCESSING_NAME_CONTEXT_ASSEMBLY.lower():
             continue
         _aid = str(rec.get("agent_id") or "")
         _corr = rec.get("correlation_id")
@@ -599,7 +692,7 @@ def _build_call_records(events: list[dict]) -> list[dict]:
         r for r in records
         if not (
             r.get("call_type") == "ProcessingCall"
-            and str(r.get("processing_name") or "").strip().lower() == "context assembly"
+            and str(r.get("processing_name") or "").strip().lower() == PROCESSING_NAME_CONTEXT_ASSEMBLY.lower()
             and r.get("correlation_id") is not None
             and (str(r.get("agent_id") or ""), r.get("correlation_id")) not in _valid_ctx_keys
         )
@@ -638,13 +731,14 @@ def _build_call_records(events: list[dict]) -> list[dict]:
             rec["call_id"] = _new_id
         _seen_ids.add(str(rec["call_id"]))
 
-    records.extend(_synthesize_context_processing_records(events, records))
+    records.extend(_synthesize_context_processing_records(events, records, _prev_context_by_agent))
 
     return sorted(records, key=lambda r: r["start_ts"])
 
 
 def _synthesize_context_processing_records(
-    events: list[dict], records: list[dict]
+    events: list[dict], records: list[dict],
+    prev_context_by_agent: dict[str, list[dict[str, str]]],
 ) -> list[dict]:
     """Create a ProcessingCall (context-assembly) node before each LLM call.
 
@@ -702,7 +796,13 @@ def _synthesize_context_processing_records(
         # dag.py clears a ProcessingCall's output from the following state, so
         # the system prompt shows only on the ⚙ context bar itself.
         context_messages = _normalize_context_messages(msgs)
-        context_parts = _context_parts_from_messages(context_messages)
+        context_parts = _context_parts_from_messages(
+            context_messages,
+            prev_messages=prev_context_by_agent.get(aid)
+        )
+        # Update tracking: this context assembly is now the "previous"
+        # for the next LLM call from this same agent.
+        prev_context_by_agent[aid] = context_messages
         cid = f"ctxasm-{aid}-{corr}"
         operation = "PREPEND" if any(msg.get("role") == "system" for msg in context_messages) else "APPEND"
         out.append({

--- a/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/tree.py
+++ b/lab/components/bench/src/mas/lab/plots/multilevel_trajectory/tree.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Optional
 
-from mas.lab.plots.multilevel_trajectory.constants import _TS_TOL
+from mas.lab.plots.multilevel_trajectory.constants import (
+    _TS_TOL,
+    PROCESSING_TYPE_WAIT_STATE,
+)
 # Tiny real (wall-clock) duration reserved for a delegation tool call's own
 # dispatch instant — shared between _align_record_boundaries (which gives the
 # delegate's own execution a start strictly after its dispatching tool call,
@@ -91,7 +94,7 @@ def _align_record_boundaries(
     def _is_wait_state(rec: dict) -> bool:
         return (
             rec.get("call_type") == "ProcessingCall"
-            and str(rec.get("processing_type") or "").strip().lower() == "wait_state"
+            and str(rec.get("processing_type") or "").strip().lower() == PROCESSING_TYPE_WAIT_STATE
         )
 
     # Envelope pass (bottom-up): a parent must temporally contain its children.

--- a/library-standard/src/mas/library/standard/lib/observability/native/boundary_handlers.py
+++ b/library-standard/src/mas/library/standard/lib/observability/native/boundary_handlers.py
@@ -284,6 +284,39 @@ def _boundary_envelope_activity(
     ]
 
 
+def _context_assembly_operation(messages: list[dict]) -> str:
+    """Determine if context operation is PREPEND (has system msg) or APPEND."""
+    return "PREPEND" if any(
+        str(m.get("role") or "").strip().lower() == "system" for m in messages
+    ) else "APPEND"
+
+
+def _add_provenance_fields(event: dict, seg: dict, is_rag: bool) -> None:
+    """Add optional provenance fields from segment to context_part_contributed event."""
+    # Plugin/Origin identification
+    origin_id = seg.get("origin_id") or seg.get("plugin_id") or seg.get("skill_name")
+    if origin_id:
+        event["origin_id"] = origin_id
+    
+    # Retrieval metadata
+    if is_rag or seg.get("mechanism") == "retrieval":
+        for key in ("retrieval_query", "retrieval_source", "retrieval_rank"):
+            if seg.get(key):
+                event[key] = seg[key]
+        if seg.get("retrieval_confidence") is not None:
+            event["retrieval_confidence"] = seg["retrieval_confidence"]
+    
+    # Decision metadata
+    if seg.get("decision_rank"):
+        event["decision_rank"] = seg["decision_rank"]
+    if seg.get("decision_score") is not None:
+        event["decision_score"] = seg["decision_score"]
+    
+    # Synthesis metadata
+    if seg.get("synthesis_rule_id"):
+        event["synthesis_rule_id"] = seg["synthesis_rule_id"]
+
+
 def _boundary_context_assembled(
     record: dict,
     *,
@@ -314,29 +347,26 @@ def _boundary_context_assembled(
     # prompt text is available. (trace_content is honoured upstream: the
     # operator omits messages when content tracing is disabled.)
     _asm_msgs = payload.get("messages") or []
-    _operation = "PREPEND" if any(str(m.get("role") or "").strip().lower() == "system" for m in _asm_msgs) else "APPEND"
+    _operation = _context_assembly_operation(_asm_msgs)
     _proc_call_id = _interval_call_id(ctx, cid, "PROCESSING_CALL:context_assembly") if cid else ""
-    _proc_start = {
-        "kind": "processing_call_start",
+    
+    # Common fields for processing call start/end
+    _proc_common = {
         **base,
         "call_id": _proc_call_id,
-        "timestamp": ts,
         "processing_name": "context assembly",
         "processing_type": "context_assembly",
         "context_operation": _operation,
         "messages": _asm_msgs,
     }
+    _proc_start = {"kind": "processing_call_start", "timestamp": ts, **_proc_common}
     _proc_end = {
         "kind": "processing_call_end",
-        **base,
-        "call_id": _proc_call_id,
         "timestamp": ts + _SYNTHETIC_SPAN_DURATION_S,
-        "processing_name": "context assembly",
-        "processing_type": "context_assembly",
-        "context_operation": _operation,
-        "messages": _asm_msgs,
         "synthetic": True,
+        **_proc_common,
     }
+    
     _ca: dict = {
         "kind": "context_assembled",
         **base,
@@ -360,22 +390,26 @@ def _boundary_context_assembled(
         mechanism = str(seg.get("mechanism") or "")
         source = str(seg.get("source") or "")
         is_rag = mechanism == "rag" or "rag" in source.lower()
-        out.append(
-            {
-                "kind": "context_part_contributed",
-                "agent_id": agent_id,
-                "timestamp": ts,
-                "llm_call_id": llm_call_id,
-                "part_id": seg.get("part_id", ""),
-                "source": seg.get("source", ""),
-                "section_id": seg.get("section_id", ""),
-                "mechanism": seg.get("mechanism") or ("rag" if is_rag else "inject"),
-                "token_estimate": seg.get("tokens", 0),
-                "retained": seg.get("retained", True),
-                "content_preview": seg.get("content_preview", ""),
-                "role": seg.get("role", ""),
-            }
-        )
+        
+        # Build context_part_contributed event with full provenance
+        cpc_event: dict = {
+            "kind": "context_part_contributed",
+            "agent_id": agent_id,
+            "timestamp": ts,
+            "llm_call_id": llm_call_id,
+            "part_id": seg.get("part_id", ""),
+            "source": seg.get("source", ""),
+            "section_id": seg.get("section_id", ""),
+            "mechanism": seg.get("mechanism") or ("rag" if is_rag else "inject"),
+            "token_estimate": seg.get("tokens", 0),
+            "retained": seg.get("retained", True),
+            "content_preview": seg.get("content_preview") or (seg.get("content", "")[:120] if seg.get("content") else ""),
+            "role": seg.get("role", ""),
+        }
+        _add_provenance_fields(cpc_event, seg, is_rag)
+        out.append(cpc_event)
+        
+        # Emit RAG query events if mechanism is RAG
         if is_rag:
             rag_call_id = f"rag-{cid}-{seg.get('part_id', '')[:8]}"
             out.extend(


### PR DESCRIPTION
CHANGES:
• Runtime: Track provenance metadata (origin_id, retrieval, decision, synthesis fields)
• Plot layer: Derive actor/trigger/via/cause deterministically from (role, source) pair
• UI: Replaced pie chart with inline category breakdown (e.g., "System 91% (318t)") for clearer token distribution visibility
• Records: Added context parts enrichment with delegation tracking and proper ordering
• Consolidation: Semantic inference logic moved to centralized _derive_context_semantics using data-driven lookup tables
• Refactoring: Extracted _normalized_str() helper to eliminate redundant strip().lower() pattern
• Constants: Defined PROCESSING_TYPE_* and PROCESSING_NAME_* constants in centralized location to eliminate hardcoded strings across dag.py and records.py
• Boundary handlers: Simplified _boundary_context_assembled with helper functions for cleaner provenance extraction

Signed-off-by: Jordan Augé <augjorda@cisco.com>
