### PR TITLE
feat(bench): attach pipelines to experiments via --pipeline CLI flag

### DIFF
--- a/lab/components/bench/src/mas/lab/benchmark/engine.py
+++ b/lab/components/bench/src/mas/lab/benchmark/engine.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,34 @@ class BenchmarkRunOptions:
     data_cache_dir: Path | None = None
     strategy: str | None = None
     step_overrides: list = field(default_factory=list)
+    pipeline_attachments: list = field(default_factory=list)
     clean_stale: bool | None = None
+
+    @classmethod
+    def from_spec(cls, spec: dict[str, Any]) -> "BenchmarkRunOptions":
+        """Construct from a controller wire dict (as produced by the CLI ``spec`` mapping)."""
+        _path = lambda k: Path(spec[k]) if spec.get(k) else None  # noqa: E731
+        return cls(
+            progress=spec.get("progress", True),
+            resume=spec.get("resume", False),
+            force=spec.get("force", False),
+            benchmark_id=spec.get("benchmark_id"),
+            dry_run=spec.get("dry_run", False),
+            max_runs=spec.get("max_runs"),
+            limit_scenarios=spec.get("limit_scenarios"),
+            sample_scenarios=spec.get("sample_scenarios"),
+            single_run=spec.get("single_run", False),
+            output_dir=_path("output_dir"),
+            trace_cache_dir=_path("trace_cache_dir"),
+            data_cache_dir=_path("data_cache_dir"),
+            force_lock=spec.get("force_lock", False),
+            flavour_name=spec.get("flavour_name"),
+            infra_name=spec.get("infra_name"),
+            strategy=spec.get("strategy"),
+            step_overrides=spec.get("step_overrides") or [],
+            pipeline_attachments=spec.get("pipeline_attachments") or [],
+            clean_stale=spec.get("clean_stale"),
+        )
 
 
 def _is_mas_experiment_yaml(experiment_yaml: Path) -> bool:
@@ -103,6 +130,7 @@ async def run_benchmark(
         output_dir=opts.output_dir,
         strategy=opts.strategy,
         step_overrides=opts.step_overrides,
+        pipeline_attachments=opts.pipeline_attachments,
         clean_stale=opts.clean_stale,
     )
 

--- a/lab/components/bench/src/mas/lab/benchmark/execution/pipeline_attach.py
+++ b/lab/components/bench/src/mas/lab/benchmark/execution/pipeline_attach.py
@@ -1,0 +1,83 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+"""CLI pipeline attachment for benchmark experiments."""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_LEVEL_ALIASES = {"experiment": "application"}
+_VALID_LEVELS = frozenset({"run", "test", "scenario", "application"})
+_VALID_PHASES = frozenset({"pre", "post"})
+
+
+def parse_pipeline_attachment(raw: str) -> Tuple[str, str, str]:
+    """Parse ``LEVEL:PHASE:REF`` or ``LEVEL:REF`` (phase defaults to post).
+
+    *REF* may contain colons (e.g. ``library:eti-apps/pipelines/foo.yaml``).
+    Returns ``(level, phase, ref)``.
+    """
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("empty pipeline attachment")
+    parts = text.split(":")
+    if len(parts) < 2:
+        raise ValueError(
+            f"invalid pipeline attachment {raw!r} — expected LEVEL:REF or LEVEL:PHASE:REF"
+        )
+    level = parts[0].strip().lower()
+    level = _LEVEL_ALIASES.get(level, level)
+    if level not in _VALID_LEVELS:
+        raise ValueError(
+            f"invalid pipeline level {parts[0]!r} — expected one of "
+            f"{sorted(_VALID_LEVELS)} (experiment aliases application)"
+        )
+    if len(parts) >= 3 and parts[1].strip().lower() in _VALID_PHASES:
+        phase = parts[1].strip().lower()
+        ref = ":".join(parts[2:]).strip()
+    else:
+        phase = "post"
+        ref = ":".join(parts[1:]).strip()
+    if not ref:
+        raise ValueError(f"empty pipeline ref in attachment {raw!r}")
+    return level, phase, ref
+
+
+def merge_pipeline_attachments(
+    data: Dict[str, Any],
+    attachments: Optional[list],
+) -> Dict[str, Any]:
+    """Append CLI pipeline refs to the experiment dict (mutates *data* in place).
+
+    Each attachment becomes a normal ``{ref: ...}`` entry under
+    ``experiment.<level>.<phase>``, as if it were declared in the YAML.
+    """
+    if not attachments:
+        return data
+
+    exp = _experiment_block(data)
+    for item in attachments:
+        level, phase, ref = parse_pipeline_attachment(item)
+        level_block = exp.setdefault(level, {})
+        if not isinstance(level_block, dict):
+            raise ValueError(f"experiment.{level} must be a mapping")
+        phase_list = level_block.setdefault(phase, [])
+        if not isinstance(phase_list, list):
+            raise ValueError(f"experiment.{level}.{phase} must be a list")
+        phase_list.append({"ref": ref})
+        logger.info("CLI pipeline merged: experiment.%s.%s ← %r", level, phase, ref)
+    return data
+
+
+def _experiment_block(data: Dict[str, Any]) -> Dict[str, Any]:
+    exp = data.get("experiment")
+    if exp is None:
+        if isinstance(data, dict) and data.get("applications") is not None:
+            return data
+        raise ValueError("experiment manifest has no experiment: block")
+    if not isinstance(exp, dict):
+        raise ValueError("experiment block must be a mapping")
+    return exp

--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/__init__.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/__init__.py
@@ -29,6 +29,7 @@ async def run_mas_benchmark(
     output_dir: Optional[Path] = None,
     strategy: Optional[str] = None,
     step_overrides: Optional[list] = None,
+    pipeline_attachments: Optional[list] = None,
     clean_stale: Optional[bool] = None,
 ) -> bool:
     """Run a MAS batch benchmark from a *MASExperimentConfig* YAML.
@@ -52,6 +53,7 @@ async def run_mas_benchmark(
         infra_name=infra_name,
         trace_cache_dir=trace_cache_dir,
         step_overrides=step_overrides,
+        pipeline_attachments=pipeline_attachments,
     )
     if loaded is None:
         return False

--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/load.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/load.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from mas.lab.benchmark.execution import parse_step_overrides
+from mas.lab.benchmark.execution.pipeline_attach import merge_pipeline_attachments
 from mas.lab.benchmark.schedule.pipeline_resolve import resolve_pipeline_specs
 
 logger = logging.getLogger(__name__)
@@ -45,19 +46,13 @@ def load_experiment(
     infra_name: Optional[str] = None,
     trace_cache_dir: Optional[Path] = None,
     step_overrides: Optional[list] = None,
+    pipeline_attachments: Optional[list] = None,
 ) -> LoadedExperiment | None:
     """Load MASExperimentConfig and resolve scenarios, dataset, flavour."""
     try:
         from mas.lab.lab.config import MASExperimentConfig
     except ImportError as exc:
         logger.error(f"Cannot import MASExperimentConfig: {exc}")
-        return None
-
-    logger.info(f"Loading MAS experiment: {experiment_yaml}")
-    try:
-        exp = MASExperimentConfig.from_yaml(experiment_yaml)
-    except Exception as exc:
-        logger.error(f"Failed to load MAS experiment YAML: {exc}")
         return None
 
     try:
@@ -68,6 +63,10 @@ def load_experiment(
         )
 
         raw = load_yaml_file(experiment_yaml)
+
+        if pipeline_attachments:
+            raw = merge_pipeline_attachments(raw, pipeline_attachments)
+
         validate_manifest(
             raw,
             source=str(experiment_yaml),
@@ -79,6 +78,13 @@ def load_experiment(
         return None
     except Exception as exc:
         logger.error("Experiment manifest validation error: %s", exc)
+        return None
+
+    logger.info(f"Loading MAS experiment: {experiment_yaml}")
+    try:
+        exp = MASExperimentConfig.from_data(raw, experiment_yaml)
+    except Exception as exc:
+        logger.error(f"Failed to load MAS experiment: {exc}")
         return None
 
     from mas.lab.lab.config import discover_lab_context, inject_lab_libraries

--- a/lab/components/bench/src/mas/lab/benchmark/worker.py
+++ b/lab/components/bench/src/mas/lab/benchmark/worker.py
@@ -67,6 +67,7 @@ def run_benchmark_sync(
     strategy: Optional[str] = None,
     infra_name: Optional[str] = None,
     step_overrides: Optional[list] = None,
+    pipeline_attachments: Optional[list] = None,
     log_sink: Optional[Callable[[str], None]] = None,
     clean_stale: Optional[bool] = None,
 ) -> bool:
@@ -115,64 +116,9 @@ def run_benchmark_sync(
     """
     _sink_handler = _attach_log_sink(log_sink) if log_sink else None
     try:
-        return asyncio.run(
-            run_benchmark_async(
-                experiment_yaml=experiment_yaml,
-                flavour_name=flavour_name,
-                force=force,
-                benchmark_id=benchmark_id,
-                dry_run=dry_run,
-                max_runs=max_runs,
-                limit_scenarios=limit_scenarios,
-                sample_scenarios=sample_scenarios,
-                single_run=single_run,
-                output_dir=output_dir,
-                trace_cache_dir=trace_cache_dir,
-                data_cache_dir=data_cache_dir,
-                force_lock=force_lock,
-                strategy=strategy,
-                infra_name=infra_name,
-                step_overrides=step_overrides,
-                clean_stale=clean_stale,
-            )
-        )
-    finally:
-        if _sink_handler is not None:
-            logging.getLogger().removeHandler(_sink_handler)
+        from mas.lab.benchmark.engine import BenchmarkRunOptions  # noqa: PLC0415
 
-
-async def run_benchmark_async(
-    experiment_yaml: str | Path,
-    *,
-    flavour_name: str = "local",
-    force: bool = False,
-    benchmark_id: Optional[str] = None,
-    dry_run: bool = False,
-    max_runs: Optional[int] = None,
-    limit_scenarios: Optional[int] = None,
-    sample_scenarios: Optional[int] = None,
-    single_run: bool = False,
-    output_dir: Optional[str | Path] = None,
-    trace_cache_dir: Optional[str | Path] = None,
-    data_cache_dir: Optional[str | Path] = None,
-    force_lock: bool = False,
-    strategy: Optional[str] = None,
-    infra_name: Optional[str] = None,
-    step_overrides: Optional[list] = None,
-    clean_stale: Optional[bool] = None,
-) -> bool:
-    """Async variant — use when already inside an asyncio event loop.
-
-    Signature mirrors :func:`run_benchmark_sync` without ``log_sink``
-    (attach a handler separately if needed).
-    """
-    # Lazy import — cli_benchmark is a heavy module; don't pay the cost at
-    # import time when only the data-access layer is needed.
-    from mas.lab.benchmark.engine import BenchmarkRunOptions, run_benchmark  # noqa: PLC0415
-
-    return await run_benchmark(
-        experiment_yaml=Path(experiment_yaml),
-        options=BenchmarkRunOptions(
+        opts = BenchmarkRunOptions(
             progress=False,
             flavour_name=flavour_name,
             force=force,
@@ -189,8 +135,30 @@ async def run_benchmark_async(
             strategy=strategy,
             infra_name=infra_name,
             step_overrides=step_overrides or [],
+            pipeline_attachments=pipeline_attachments or [],
             clean_stale=clean_stale,
-        ),
+        )
+        return asyncio.run(run_benchmark_async(experiment_yaml, options=opts))
+    finally:
+        if _sink_handler is not None:
+            logging.getLogger().removeHandler(_sink_handler)
+
+
+async def run_benchmark_async(
+    experiment_yaml: str | Path,
+    *,
+    options: "BenchmarkRunOptions | None" = None,
+) -> bool:
+    """Async variant — use when already inside an asyncio event loop.
+
+    Accepts a :class:`~mas.lab.benchmark.engine.BenchmarkRunOptions` directly;
+    pass ``options=BenchmarkRunOptions(...)`` to override any field.
+    """
+    from mas.lab.benchmark.engine import BenchmarkRunOptions, run_benchmark  # noqa: PLC0415
+
+    return await run_benchmark(
+        experiment_yaml=Path(experiment_yaml),
+        options=options or BenchmarkRunOptions(),
     )
 
 

--- a/lab/components/bench/src/mas/lab/lab/config/mas_experiment.py
+++ b/lab/components/bench/src/mas/lab/lab/config/mas_experiment.py
@@ -28,7 +28,16 @@ class MASExperimentConfig(MASRunBase):
     def from_yaml(cls, path: Path) -> "MASExperimentConfig":
         """Load a MASExperimentConfig from an experiment YAML file."""
         data, _manifest_version = load_experiment_data(path)
+        return cls.from_data(data, path)
 
+    @classmethod
+    def from_data(cls, data: dict, path: Path) -> "MASExperimentConfig":
+        """Construct from an already-loaded dict (e.g. after CLI merges).
+
+        Accepts the same ``data`` shape that :func:`load_experiment_data`
+        returns — a raw YAML dict that may have been modified in-memory
+        before construction (e.g. ``merge_pipeline_attachments``).
+        """
         exp_data = data.get("experiment", data)
         base_dir = path.parent
 

--- a/lab/components/bench/tests/test_pipeline_resolve.py
+++ b/lab/components/bench/tests/test_pipeline_resolve.py
@@ -1,16 +1,46 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-"""Tests for unified pipeline resolution and phase execution."""
+"""Tests for unified pipeline resolution and phase execution.
+
+Coverage
+--------
+* ``resolve_pipeline_specs()`` — in isolation (mock exp objects)
+* ``materialize_step_dicts()`` — phase filtering
+* ``merge_pipeline_attachments()`` — dict mutation from CLI ``--pipeline`` flags
+* ``MASExperimentConfig.from_data()`` — constructs exp from in-memory dict
+* CLI attachment → ``from_data`` → ``all_pipeline_steps()`` end-to-end
+
+The last two groups were missing before and allowed a bug to ship: CLI-attached
+pipelines were merged into the raw validation dict but the exp object was
+constructed from the YAML file, so ``all_pipeline_steps()`` never saw them.
+"""
 from __future__ import annotations
 
 from pathlib import Path
 
 import yaml
 
+from mas.lab.benchmark.execution.pipeline_attach import merge_pipeline_attachments
 from mas.lab.benchmark.schedule.pipeline import materialize_step_dicts
 from mas.lab.benchmark.schedule.pipeline_resolve import resolve_pipeline_specs
 from mas.lab.lab.config import PipelineStepSpec
+from mas.lab.lab.config.mas_experiment import MASExperimentConfig
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_EXPERIMENT = {
+    "experiment": {
+        "name": "test-exp",
+        "applications": [{"manifest": "mas.yaml"}],
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# resolve_pipeline_specs — mock exp objects
+# ---------------------------------------------------------------------------
 
 def test_resolve_inline_specs_from_experiment_dict():
     class _Exp:
@@ -65,3 +95,185 @@ def test_materialize_filters_by_phase():
     post = materialize_step_dicts(specs, phase="post", scenario_ids=["s1"], infra_name=None, step_overrides={})
     assert [s["name"] for s in pre] == ["start"]
     assert [s["name"] for s in post] == ["stats"]
+
+
+# ---------------------------------------------------------------------------
+# merge_pipeline_attachments — dict structure
+# ---------------------------------------------------------------------------
+
+def test_merge_injects_ref_into_correct_level_and_phase():
+    """merge_pipeline_attachments must place {ref:} entries under experiment.<level>.<phase>."""
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    result = merge_pipeline_attachments(raw, [
+        "run:post:pipelines/stats.yaml",
+        "scenario:pre:pipelines/setup.yaml",
+    ])
+    assert result["experiment"]["run"]["post"] == [{"ref": "pipelines/stats.yaml"}]
+    assert result["experiment"]["scenario"]["pre"] == [{"ref": "pipelines/setup.yaml"}]
+
+
+def test_merge_appends_to_existing_level_phase():
+    """CLI attachments must append, not overwrite, existing pipeline entries."""
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    raw["experiment"]["run"] = {"post": [{"type": "extract_trace_stats", "name": "existing"}]}
+    result = merge_pipeline_attachments(raw, ["run:post:pipelines/extra.yaml"])
+    assert len(result["experiment"]["run"]["post"]) == 2
+    assert result["experiment"]["run"]["post"][1] == {"ref": "pipelines/extra.yaml"}
+
+
+def test_merge_phase_defaults_to_post():
+    """LEVEL:REF (no phase) must inject into post."""
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    result = merge_pipeline_attachments(raw, ["run:pipelines/stats.yaml"])
+    assert result["experiment"]["run"]["post"] == [{"ref": "pipelines/stats.yaml"}]
+
+
+# ---------------------------------------------------------------------------
+# MASExperimentConfig.from_data — level pipeline visibility
+# ---------------------------------------------------------------------------
+
+def test_from_data_sees_inline_level_pipeline_steps():
+    """from_data must populate exp.levels from the supplied dict, not re-read the file."""
+    data = {
+        "experiment": {
+            "name": "test-exp",
+            "applications": [{"manifest": "mas.yaml"}],
+            "run": {"post": [{"type": "extract_trace_stats", "name": "stats"}]},
+            "scenario": {"pre": [{"type": "service_start", "name": "start"}]},
+        }
+    }
+    exp = MASExperimentConfig.from_data(data, Path("/tmp/exp.yaml"))
+    steps = exp.all_pipeline_steps()
+    assert len(steps) == 2
+    by_type = {s.type: s for s in steps}
+    assert by_type["extract_trace_stats"].scope == "run"
+    assert by_type["extract_trace_stats"].phase == "post"
+    assert by_type["service_start"].scope == "scenario"
+    assert by_type["service_start"].phase == "pre"
+
+
+# ---------------------------------------------------------------------------
+# merge + from_data end-to-end  (the bug scenario)
+# ---------------------------------------------------------------------------
+
+def test_cli_pipeline_attachment_reaches_all_pipeline_steps(tmp_path: Path):
+    """CLI --pipeline attachments must appear in exp.all_pipeline_steps().
+
+    This test covers the bug where merge_pipeline_attachments patched the raw
+    validation dict but the exp object was constructed from the YAML file, so
+    CLI-attached pipelines were silently dropped.
+    """
+    # Create a real pipeline file the attachment will reference
+    pipeline_yaml = tmp_path / "stats.yaml"
+    pipeline_yaml.write_text(
+        yaml.dump({
+            "pipeline": {
+                "name": "stats",
+                "steps": [{"name": "s", "type": "extract_trace_stats", "phase": "post"}],
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    merged = merge_pipeline_attachments(raw, [f"run:post:{pipeline_yaml}"])
+
+    exp = MASExperimentConfig.from_data(merged, tmp_path / "exp.yaml")
+    steps = exp.all_pipeline_steps()
+
+    assert len(steps) == 1, (
+        "CLI-attached pipeline step must be visible in all_pipeline_steps(). "
+        "If this fails, from_data is not using the merged dict."
+    )
+    assert steps[0].type == "extract_trace_stats"
+    assert steps[0].scope == "run"
+    assert steps[0].phase == "post"
+
+
+def test_multiple_cli_attachments_across_levels(tmp_path: Path):
+    """Multiple --pipeline flags across different levels must all appear."""
+    def _make_pipeline(name: str, step_type: str) -> Path:
+        p = tmp_path / f"{name}.yaml"
+        p.write_text(
+            yaml.dump({
+                "pipeline": {
+                    "name": name,
+                    "steps": [{"name": name, "type": step_type, "phase": "post"}],
+                }
+            }),
+            encoding="utf-8",
+        )
+        return p
+
+    run_pipe = _make_pipeline("run-stats", "extract_trace_stats")
+    scenario_pipe = _make_pipeline("scenario-stats", "extract_mealy_stats")
+
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    merged = merge_pipeline_attachments(raw, [
+        f"run:post:{run_pipe}",
+        f"scenario:post:{scenario_pipe}",
+    ])
+
+    exp = MASExperimentConfig.from_data(merged, tmp_path / "exp.yaml")
+    steps = exp.all_pipeline_steps()
+
+    assert len(steps) == 2
+    types = {s.type for s in steps}
+    assert "extract_trace_stats" in types
+    assert "extract_mealy_stats" in types
+    scopes = {s.scope for s in steps}
+    assert scopes == {"run", "scenario"}
+
+
+def test_yaml_and_cli_pipelines_compose_into_same_structure(tmp_path: Path):
+    """YAML-declared pipelines + CLI --pipeline flags = union of all steps.
+
+    Whether steps come from the YAML, from the CLI, or a mix, the result must
+    be identical to declaring all of them in one place.  This test verifies
+    that the 'one in-memory structure' invariant holds.
+    """
+    cli_pipe = tmp_path / "cli.yaml"
+    cli_pipe.write_text(
+        yaml.dump({
+            "pipeline": {
+                "name": "cli",
+                "steps": [{"name": "cli-step", "type": "extract_mealy_stats", "phase": "post"}],
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    # Experiment YAML declares 2 inline steps at different levels
+    import copy
+    raw = copy.deepcopy(_MINIMAL_EXPERIMENT)
+    raw["experiment"]["run"] = {
+        "post": [{"type": "extract_trace_stats", "name": "yaml-run"}]
+    }
+    raw["experiment"]["scenario"] = {
+        "post": [{"type": "service_start", "name": "yaml-scenario"}]
+    }
+
+    # CLI adds a third step (also at run level)
+    merged = merge_pipeline_attachments(raw, [f"run:post:{cli_pipe}"])
+
+    exp = MASExperimentConfig.from_data(merged, tmp_path / "exp.yaml")
+    steps = exp.all_pipeline_steps()
+
+    assert len(steps) == 3, (
+        "All steps — whether from YAML or CLI — must appear in all_pipeline_steps(). "
+        f"Got: {[(s.type, s.scope, s.phase) for s in steps]}"
+    )
+    types = {s.type for s in steps}
+    assert types == {"extract_trace_stats", "service_start", "extract_mealy_stats"}
+
+    # YAML-declared run steps come before CLI-appended ones (append semantics)
+    run_steps = [s for s in steps if s.scope == "run"]
+    assert len(run_steps) == 2
+    assert run_steps[0].type == "extract_trace_stats"   # YAML first
+    assert run_steps[1].type == "extract_mealy_stats"   # CLI appended after
+

--- a/lab/components/controller/src/mas/lab/controller/workers.py
+++ b/lab/components/controller/src/mas/lab/controller/workers.py
@@ -90,26 +90,7 @@ def run_benchmark_worker(registry: WorkerRegistry, runner: "WorkerRunner", spec:
                 ok = asyncio.run(
                     run_benchmark(
                         experiment_yaml=experiment_yaml,
-                        options=BenchmarkRunOptions(
-                            progress=spec.get("progress", True),
-                            resume=spec.get("resume", False),
-                            force=spec.get("force", False),
-                            benchmark_id=spec.get("benchmark_id"),
-                            dry_run=spec.get("dry_run", False),
-                            max_runs=spec.get("max_runs"),
-                            limit_scenarios=spec.get("limit_scenarios"),
-                            sample_scenarios=spec.get("sample_scenarios"),
-                            single_run=spec.get("single_run", False),
-                            output_dir=Path(spec["output_dir"]) if spec.get("output_dir") else None,
-                            trace_cache_dir=Path(spec["trace_cache_dir"]) if spec.get("trace_cache_dir") else None,
-                            data_cache_dir=Path(spec["data_cache_dir"]) if spec.get("data_cache_dir") else None,
-                            force_lock=spec.get("force_lock", False),
-                            flavour_name=spec.get("flavour_name"),
-                            infra_name=spec.get("infra_name"),
-                            strategy=spec.get("strategy"),
-                            step_overrides=spec.get("step_overrides") or [],
-                            clean_stale=spec.get("clean_stale"),
-                        ),
+                        options=BenchmarkRunOptions.from_spec(spec),
                     )
                 )
             except Exception:

--- a/lab/src/mas/lab/cli/commands/benchmark/run.py
+++ b/lab/src/mas/lab/cli/commands/benchmark/run.py
@@ -67,6 +67,18 @@ import click
                   "Value is auto-coerced: 'true'/'false' → bool, integers → int. "
                   "Can be repeated for multiple overrides."
               ))
+@click.option(
+    "--pipeline",
+    "pipeline_attachments",
+    multiple=True,
+    metavar="LEVEL[:PHASE]:REF",
+    help=(
+        "Attach a pipeline YAML after experiment hooks (same order as repeated flags). "
+        "Format: run:post:library:eti-apps/pipelines/observability/native-to-kg.yaml "
+        "or run:library:... (phase defaults to post). "
+        "Levels: run, test, scenario, application (experiment aliases application)."
+    ),
+)
 @click.option("-b", "--background", "background", is_flag=True, default=False,
               help="Submit via controller daemon and return immediately (print worker id).")
 @click.option("--clean-stale", "clean_stale", is_flag=True, default=False,
@@ -78,7 +90,8 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
             single_run: bool, output_dir: Path | None, trace_cache_dir: Path | None,
             data_cache_dir: Path | None,
             force_lock: bool, flavour: str | None, infra: str | None, strategy: str | None,
-            step_overrides: tuple[str, ...], background: bool, clean_stale: bool) -> None:
+            step_overrides: tuple[str, ...], pipeline_attachments: tuple[str, ...],
+            background: bool, clean_stale: bool) -> None:
     """Run a benchmark from an experiment YAML via the controller daemon.
 
     MAS ``--dry-run`` (without ``-b``) validates in-process — no daemon required.
@@ -108,6 +121,7 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
                 infra_name=infra,
                 strategy=strategy,
                 step_overrides=list(step_overrides),
+                pipeline_attachments=list(pipeline_attachments),
                 clean_stale=clean_stale or None,
             )
             raise SystemExit(0 if ok else 1)
@@ -133,6 +147,7 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
         "infra_name": infra,
         "strategy": strategy,
         "step_overrides": list(step_overrides),
+        "pipeline_attachments": list(pipeline_attachments),
         "clean_stale": clean_stale,
     }
 


### PR DESCRIPTION
Add `--pipeline LEVEL[:PHASE]:REF` to `mas-lab benchmark run`.
Repeatable and ordered. Phase defaults to post when omitted.
Levels: run, test, scenario, application (experiment aliases application).

  mas-lab benchmark run experiment.yaml \
    --pipeline 'run:post:library:pipelines/native-to-kg.yaml' \
    --pipeline 'scenario:library:path/to/analyze.yaml'

CLI attachments and YAML-declared pipelines share the same code path:
load_experiment() merges CLI refs into the raw YAML dict, validates it,
then constructs MASExperimentConfig via from_data() from the merged dict.
All pipelines — regardless of origin — land in MASExperimentConfig.levels
and flow through resolve_pipeline_specs() identically. YAML steps come
first within a level; CLI steps are appended in flag order.

New code
--------
pipeline_attach.py
  parse_pipeline_attachment()  — parse LEVEL[:PHASE]:REF → (level, phase, ref)
  merge_pipeline_attachments() — inject {ref:} entries into the raw YAML dict
                                 under experiment.<level>.<phase>

MASExperimentConfig.from_data(data, path)
  Construct from an in-memory dict. from_yaml() now delegates to it.

BenchmarkRunOptions.pipeline_attachments
  New field. Carried from CLI through worker, engine, scheduler to load_experiment.

BenchmarkRunOptions.from_spec(spec)
  Construct from the controller wire dict (replaces inline spec.get() chains).

run_benchmark_async(experiment_yaml, *, options)
  Signature simplified: accepts BenchmarkRunOptions directly.
