### PR TITLE
fix(ctl): addded trace flag to mas-ctl run-mas

### DIFF
--- a/ctl/src/mas/ctl/cli/commands/chat.py
+++ b/ctl/src/mas/ctl/cli/commands/chat.py
@@ -11,6 +11,7 @@ import click
 
 from mas.ctl.session.bootstrap import InstantiationOptions, instantiate_runtime
 from mas.ctl.cli.obs_flags import observability_options, resolve_observability_config
+from mas.ctl.cli.trace_flags import trace_options
 from mas.ctl.session.controller import (
     ConversationConfig,
     SessionController,
@@ -69,31 +70,7 @@ from mas.ctl.ui.stdout import StdoutConversationDisplay
     help="Disable governance summand (M_gov), policy evaluation, and HITL chokepoints",
 )
 @observability_options
-@click.option(
-    "--trace",
-    is_flag=True,
-    help="Stream AGENT↔LLM↔TOOL exchanges on stderr as they happen",
-)
-@click.option(
-    "--trace-timestamps",
-    is_flag=True,
-    help="With --trace: UTC timestamp and +elapsed on each exchange",
-)
-@click.option(
-    "--trace-engine",
-    is_flag=True,
-    help="With --trace: raw InvokeEngineIo / EngineIoReturn JSON (also -vv)",
-)
-@click.option(
-    "--trace-summary",
-    is_flag=True,
-    help="With --trace: only print exchange headers (AGENT→LLM, LLM→AGENT, etc)",
-)
-@click.option(
-    "--trace-color",
-    is_flag=True,
-    help="With --trace: colorize output (gray=timestamp, cyan=header, yellow=metadata, white=content)",
-)
+@trace_options
 @click.option(
     "--model",
     default=None,

--- a/ctl/src/mas/ctl/cli/commands/run_mas.py
+++ b/ctl/src/mas/ctl/cli/commands/run_mas.py
@@ -11,6 +11,7 @@ import yaml
 
 from mas.ctl.cli.obs_flags import observability_options, resolve_observability_config
 from mas.ctl.cli.runtime_flags import runtime_id_choice
+from mas.ctl.cli.trace_flags import trace_options
 from mas.ctl.deployment.runtime_id import DEFAULT_RUNTIME_ID
 from mas.ctl.executor.run_mas import execute_run_mas
 
@@ -42,6 +43,7 @@ from mas.ctl.executor.run_mas import execute_run_mas
 @click.option("--single-turn", is_flag=True)
 @click.option("--no-validate", is_flag=True)
 @observability_options
+@trace_options
 @click.pass_context
 def run_mas_cmd(
     ctx: click.Context,
@@ -61,6 +63,11 @@ def run_mas_cmd(
     events_file,
     events_stdout,
     events_format,
+    trace: bool,
+    trace_timestamps: bool,
+    trace_engine: bool,
+    trace_summary: bool,
+    trace_color: bool,
 ) -> None:
     """Run a MAS manifest (compose → materialize → session on entry agent)."""
     from mas.ctl.paths import manifest_cwd, resolve_overlay_path
@@ -113,5 +120,10 @@ def run_mas_cmd(
             verbose=verbose,
             manifest_dir=session.manifest_dir,
             obs_config=obs_cfg,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine or verbose >= 2,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
         )
     raise SystemExit(rc)

--- a/ctl/src/mas/ctl/cli/trace_flags.py
+++ b/ctl/src/mas/ctl/cli/trace_flags.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Shared CLI exchange-tracing flags — see SessionController._setup_exchange_tracing."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import click
+
+
+def trace_options(fn: Callable) -> Callable:
+    """--trace and friends, shared by every command that builds a SessionController."""
+    fn = click.option(
+        "--trace",
+        is_flag=True,
+        help="Stream AGENT↔LLM↔TOOL exchanges on stderr as they happen",
+    )(fn)
+    fn = click.option(
+        "--trace-timestamps",
+        is_flag=True,
+        help="With --trace: UTC timestamp and +elapsed on each exchange",
+    )(fn)
+    fn = click.option(
+        "--trace-engine",
+        is_flag=True,
+        help="With --trace: raw InvokeEngineIo / EngineIoReturn JSON (also -vv)",
+    )(fn)
+    fn = click.option(
+        "--trace-summary",
+        is_flag=True,
+        help="With --trace: only print exchange headers (AGENT→LLM, LLM→AGENT, etc)",
+    )(fn)
+    fn = click.option(
+        "--trace-color",
+        is_flag=True,
+        help="With --trace: colorize output (gray=timestamp, cyan=header, yellow=metadata, white=content)",
+    )(fn)
+    return fn

--- a/ctl/src/mas/ctl/executor/mas_session.py
+++ b/ctl/src/mas/ctl/executor/mas_session.py
@@ -202,6 +202,11 @@ def prepare_delegation_entry_session(
     display: Any = None,
     verbose: int = 0,
     session_id: str = "",
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> PreparedEntrySession:
     """Wire dynamic-delegation entry agent (same path as ``execute_run_mas``).
 
@@ -244,6 +249,11 @@ def prepare_delegation_entry_session(
             verbose=verbose,
             from_agent=entry_id,
             session_id=resolved_session_id,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
         ),
         entry_agent_id=entry_id,
         mas_config=compose.mas_config,
@@ -266,6 +276,11 @@ def wire_peer_delegation(
     verbose: int = 0,
     already_wired: "set[str] | None" = None,
     session_id: str = "",
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> list[str]:
     """Wire delegation onto every agent that declares its own ``delegates_to``
     peers in the MAS workflow topology — not just the entry agent.
@@ -301,6 +316,11 @@ def wire_peer_delegation(
         verbose=verbose,
         from_agent=entry_id,
         session_id=session_id,
+        trace=trace,
+        trace_timestamps=trace_timestamps,
+        trace_engine=trace_engine,
+        trace_summary=trace_summary,
+        trace_color=trace_color,
     )
     newly_wired: list[str] = []
     for agent in compose.bind.agents:
@@ -342,6 +362,11 @@ def make_workflow_send(
     verbose: int,
     from_agent: str = "",
     session_id: str = "",
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> RunTurnFn:
     """Run one agent turn inside a multi-agent workflow (sequential or delegation).
 
@@ -433,6 +458,11 @@ def make_workflow_send(
             instance=instance,
             display=sub_display,
             verbose=verbose,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
             agent_id=agent_id,
             config=ConversationConfig(single_turn=True),
             session_id=state["session_id"],
@@ -464,6 +494,11 @@ def run_sequential_workflow_queries(
     display: Any,
     verbose: int = 0,
     session_id: str = "",
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> str:
     """Execute sequential workflow queries; returns final response text.
 
@@ -482,6 +517,11 @@ def run_sequential_workflow_queries(
         verbose=verbose,
         from_agent=entry,
         session_id=session_id,
+        trace=trace,
+        trace_timestamps=trace_timestamps,
+        trace_engine=trace_engine,
+        trace_summary=trace_summary,
+        trace_color=trace_color,
     )
     wf = SequentialWorkflow.from_dict(sequential_workflow_payload(mas_config), send=send)
     text = ""

--- a/ctl/src/mas/ctl/executor/run_mas.py
+++ b/ctl/src/mas/ctl/executor/run_mas.py
@@ -57,6 +57,11 @@ def execute_run_mas(
     verbose: int = 0,
     manifest_dir: Path | None = None,
     obs_config=None,
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> int:
     """Compose → materialize → workflow or SessionController on entry agent."""
     from mas.ctl.session.controller import ConversationConfig, SessionController, close_observability
@@ -110,6 +115,11 @@ def execute_run_mas(
             verbose=verbose,
             obs_config=obs_config,
             base=base,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
         )
 
     entry = entry_agent_id(result.mas_config)
@@ -125,6 +135,11 @@ def execute_run_mas(
             entry_id=entry,
             display=display,
             verbose=verbose,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
         )
     except KeyError as exc:
         logger.error("%s", exc)
@@ -146,6 +161,11 @@ def execute_run_mas(
         verbose=verbose,
         already_wired={entry},
         session_id=prepared.session_id,
+        trace=trace,
+        trace_timestamps=trace_timestamps,
+        trace_engine=trace_engine,
+        trace_summary=trace_summary,
+        trace_color=trace_color,
     )
 
     if runtime_params:
@@ -176,6 +196,11 @@ def execute_run_mas(
         instance=instance,
         display=display,
         verbose=verbose,
+        trace=trace,
+        trace_timestamps=trace_timestamps,
+        trace_engine=trace_engine,
+        trace_summary=trace_summary,
+        trace_color=trace_color,
         agent_id=str(entry or "agent"),
         config=ConversationConfig(
             single_turn=single_turn or (bool(scripted) and not interactive),
@@ -203,6 +228,11 @@ def _run_sequential_workflow(
     verbose: int,
     obs_config,
     base: Path,
+    trace: bool = False,
+    trace_timestamps: bool = False,
+    trace_engine: bool = False,
+    trace_summary: bool = False,
+    trace_color: bool = False,
 ) -> int:
     from mas.ctl.ui.stdout import StdoutConversationDisplay
 
@@ -228,6 +258,11 @@ def _run_sequential_workflow(
             scripted,
             display=display,
             verbose=verbose,
+            trace=trace,
+            trace_timestamps=trace_timestamps,
+            trace_engine=trace_engine,
+            trace_summary=trace_summary,
+            trace_color=trace_color,
         )
     except (KeyError, RuntimeError, ValueError) as exc:
         logger.error("sequential workflow failed: %s", exc)


### PR DESCRIPTION
- add -trace to mas-ctl run-mas and refactor
- cleanup tests which still referenced older interfaces like
  note_user_input

Signed-off-by: Jordan Augé <jordan.auge@cisco.com>
