### PR TITLE
fix(compose): resolve overlay-injected design_pattern from entry.spec when entry top-level is absent

### DIFF
--- a/ctl/src/mas/ctl/compose/pattern_registry.py
+++ b/ctl/src/mas/ctl/compose/pattern_registry.py
@@ -51,8 +51,9 @@ def pattern_for_agent(
         name = entry.get("name", entry.get("id", ""))
         if name != agent_id:
             continue
-        if entry.get("design_pattern"):
-            return resolve_design_pattern_registry_id(entry["design_pattern"])
+        dp = entry.get("design_pattern") or (entry.get("spec") or {}).get("design_pattern")
+        if dp:
+            return resolve_design_pattern_registry_id(dp)
         ref = entry.get("ref") or entry.get("manifest")
         if ref and mas_base_dir:
             agent_path = (mas_base_dir / ref).resolve()


### PR DESCRIPTION
When a MAS overlay patches agents.<id>.design_pattern, merge_mas_overlay forwards it to merge_agent_overlay, which writes all per-agent keys into entry["spec"]. The pattern resolver (pattern_for_agent) only checked the top-level entry["design_pattern"], which was always None for overlay-injected patterns, causing unconditional fallback to the default plugin.

Before: entry["design_pattern"] → None → react@v1
After:  entry["design_pattern"] or entry["spec"]["design_pattern"] → centralized_moderator@v1