### PR TITLE
feat: let overlays append to an agent's prompt without duplicating it

### DIFF
--- a/ctl/src/mas/ctl/manifest/mas_agent_merge.py
+++ b/ctl/src/mas/ctl/manifest/mas_agent_merge.py
@@ -12,11 +12,8 @@ from typing import Any
 
 import yaml
 
-from mas.ctl.overlay.merge import _ops_dict
-from mas.runtime.boundary.context.manifest_context import (
-    merge_context_map,
-    routing_description_from_agent,
-)
+from mas.ctl.overlay.merge import _ops_dict, merge_context_map
+from mas.runtime.boundary.context.manifest_context import routing_description_from_agent
 from mas.runtime.boundary.delegation.llm_delegator import LlmDelegator
 from mas.runtime.boundary.delegation.policy import delegation_targets
 from mas.runtime.engine.llm_live import LiveLlmEngine

--- a/ctl/src/mas/ctl/manifest/mas_agent_merge.py
+++ b/ctl/src/mas/ctl/manifest/mas_agent_merge.py
@@ -13,7 +13,10 @@ from typing import Any
 import yaml
 
 from mas.ctl.overlay.merge import _ops_dict
-from mas.runtime.boundary.context.manifest_context import routing_description_from_agent
+from mas.runtime.boundary.context.manifest_context import (
+    merge_context_map,
+    routing_description_from_agent,
+)
 from mas.runtime.boundary.delegation.llm_delegator import LlmDelegator
 from mas.runtime.boundary.delegation.policy import delegation_targets
 from mas.runtime.engine.llm_live import LiveLlmEngine
@@ -148,19 +151,7 @@ def apply_agency_entry_overlay(
 
     ctx = entry_spec.get("context")
     if isinstance(ctx, dict) and ctx:
-        base_ctx = spec.get("context")
-        if isinstance(base_ctx, dict):
-            for key, ov in ctx.items():
-                if (bv := base_ctx.get(key)) is not None and type(bv) is not type(ov):
-                    logger.warning(
-                        "agency overlay context[%r] type %s overrides base type %s",
-                        key,
-                        type(ov).__name__,
-                        type(bv).__name__,
-                    )
-            spec["context"] = {**base_ctx, **copy.deepcopy(ctx)}
-        else:
-            spec["context"] = copy.deepcopy(ctx)
+        spec["context"] = merge_context_map(spec.get("context"), ctx)
 
     _apply_description_overlay(spec, agency_entry, entry_spec)
 

--- a/ctl/src/mas/ctl/overlay/merge.py
+++ b/ctl/src/mas/ctl/overlay/merge.py
@@ -197,8 +197,43 @@ def _merge_list_ops(
                 key = dedupe_key(item)
                 if key not in keys:
                     result.append(item)
-        
+
     return result
+
+
+def _as_fragment_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    return [value]
+
+
+def merge_context_chunk(existing: Any, incoming: Any) -> Any:
+    """Merge one spec.context.<key> overlay patch value onto its base value.
+
+    A plain value (string/{ref}/list) fully replaces the base chunk -- implicit
+    replace ergonomics, consistent with every other overlay merge strategy in
+    this repo. A `{"$op": {replace|add|remove|clear}}` value instead operates on
+    the base chunk's fragment list via the same list-patch semantics spec.tools
+    already uses (_merge_list_ops above), coercing a scalar base value to a
+    one-item list first -- so an overlay can add or remove a single fragment
+    (e.g. append one sentence to spec.context.role) without restating the rest.
+    """
+    if _ops_dict(incoming) is None:
+        return deepcopy(incoming)
+    return _merge_list_ops(_as_fragment_list(existing), incoming)
+
+
+def merge_context_map(existing: Any, incoming: dict[str, Any]) -> dict[str, Any]:
+    """Merge an overlay's spec.context patch onto the base spec.context map."""
+    merged = deepcopy(existing) if isinstance(existing, dict) else {}
+    for key, value in incoming.items():
+        if value is None:
+            merged.pop(key, None)
+            continue
+        merged[key] = merge_context_chunk(merged.get(key), value)
+    return merged
 
 
 def _merge_mapping_ops(existing: dict[str, Any], incoming: Any) -> dict[str, Any]:
@@ -277,7 +312,10 @@ def _merge_value_by_meta(existing: Any, incoming: Any, meta: dict[str, Any]) -> 
 
     if strategy == "list_ops":
         existing_list = list(existing or []) if isinstance(existing, list) else []
-        return _merge_list_ops(existing_list, incoming, dedupe_key=None)
+        try:
+            return _merge_list_ops(existing_list, incoming, dedupe_key=None)
+        except ValueError as exc:
+            raise OverlayTargetError(str(exc)) from exc
 
     if strategy == "plugin_list_ops":
         existing_list = list(existing or []) if isinstance(existing, list) else []
@@ -299,8 +337,6 @@ def _merge_value_by_meta(existing: Any, incoming: Any, meta: dict[str, Any]) -> 
 
     if strategy == "context_merge":
         if isinstance(incoming, dict):
-            from mas.runtime.boundary.context.manifest_context import merge_context_map
-
             return merge_context_map(existing, incoming)
         return deepcopy(incoming)
 

--- a/ctl/src/mas/ctl/overlay/merge.py
+++ b/ctl/src/mas/ctl/overlay/merge.py
@@ -298,16 +298,10 @@ def _merge_value_by_meta(existing: Any, incoming: Any, meta: dict[str, Any]) -> 
         return deepcopy(incoming)
 
     if strategy == "context_merge":
-        if isinstance(incoming, dict) and isinstance(existing, dict):
-            merged = deepcopy(existing)
-            merged.update(incoming)
-            return merged
         if isinstance(incoming, dict):
-            return deepcopy(incoming)
-        if isinstance(incoming, list):
-            existing_list = list(existing or []) if isinstance(existing, list) else []
-            existing_list.extend(incoming)
-            return existing_list
+            from mas.runtime.boundary.context.manifest_context import merge_context_map
+
+            return merge_context_map(existing, incoming)
         return deepcopy(incoming)
 
     if strategy == "execution_merge":

--- a/ctl/tests/test_bootstrap_context.py
+++ b/ctl/tests/test_bootstrap_context.py
@@ -54,6 +54,23 @@ def test_apply_manifest_context_reads_context_path_string(tmp_path: Path):
     assert ctx.injected_context == ["[role] Path string role."]
 
 
+def test_apply_manifest_context_reads_array_chunk_as_one_joined_line(tmp_path: Path):
+    escalation = tmp_path / "escalation.md"
+    escalation.write_text("Escalate P1 incidents immediately.", encoding="utf-8")
+    ctx = AutoCtxAssembler()
+    manifest = {
+        "spec": {
+            "context": {
+                "role": ["You are a triage agent.", {"ref": "escalation.md"}],
+            }
+        }
+    }
+    _apply_manifest_context(ctx, manifest, tmp_path)
+    assert ctx.injected_context == [
+        "[role] You are a triage agent.\nEscalate P1 incidents immediately."
+    ]
+
+
 def test_apply_manifest_context_only_reads_context_chunks():
     ctx = AutoCtxAssembler()
     manifest = {

--- a/ctl/tests/test_mas_agent_merge.py
+++ b/ctl/tests/test_mas_agent_merge.py
@@ -276,10 +276,12 @@ def test_merge_tool_ref_list_keeps_entries_without_key(caplog):
     assert "no ref/name" in caplog.text
 
 
-def test_apply_agency_entry_overlay_warns_context_type_mismatch(caplog):
+def test_apply_agency_entry_overlay_plain_context_value_replaces_regardless_of_shape():
+    """A plain (non-$op) chunk patch value is an implicit full replace, even
+    when it changes shape (e.g. {ref} -> inline string) -- same ergonomics as
+    every other overlay merge strategy in this repo."""
     from mas.ctl.manifest.mas_agent_merge import apply_agency_entry_overlay
 
-    caplog.set_level("WARNING")
     manifest = {
         "metadata": {"name": "a"},
         "spec": {"context": {"role": {"ref": "role.md"}}},
@@ -287,7 +289,24 @@ def test_apply_agency_entry_overlay_warns_context_type_mismatch(caplog):
     entry = {"id": "a", "spec": {"context": {"role": "inline role"}}}
     merged = apply_agency_entry_overlay(manifest, entry)
     assert merged["spec"]["context"]["role"] == "inline role"
-    assert "type str overrides base type dict" in caplog.text
+
+
+def test_apply_agency_entry_overlay_context_op_add_appends_without_duplicating():
+    from mas.ctl.manifest.mas_agent_merge import apply_agency_entry_overlay
+
+    manifest = {
+        "metadata": {"name": "a"},
+        "spec": {"context": {"role": "You are a triage agent."}},
+    }
+    entry = {
+        "id": "a",
+        "spec": {"context": {"role": {"$op": {"add": ["Escalate P1s immediately."]}}}},
+    }
+    merged = apply_agency_entry_overlay(manifest, entry)
+    assert merged["spec"]["context"]["role"] == [
+        "You are a triage agent.",
+        "Escalate P1s immediately.",
+    ]
 
 
 def test_agency_entries_by_id_prefers_agency_bucket():

--- a/ctl/tests/test_mas_agent_merge.py
+++ b/ctl/tests/test_mas_agent_merge.py
@@ -291,6 +291,20 @@ def test_apply_agency_entry_overlay_plain_context_value_replaces_regardless_of_s
     assert merged["spec"]["context"]["role"] == "inline role"
 
 
+def test_apply_agency_entry_overlay_plain_array_context_value_replaces_not_adds():
+    """A plain array chunk patch (no `$op`) fully replaces, mirroring the
+    plain-string case above -- it does NOT append onto the base fragments."""
+    from mas.ctl.manifest.mas_agent_merge import apply_agency_entry_overlay
+
+    manifest = {
+        "metadata": {"name": "a"},
+        "spec": {"context": {"role": ["a", "b"]}},
+    }
+    entry = {"id": "a", "spec": {"context": {"role": ["c", "d"]}}}
+    merged = apply_agency_entry_overlay(manifest, entry)
+    assert merged["spec"]["context"]["role"] == ["c", "d"]
+
+
 def test_apply_agency_entry_overlay_context_op_add_appends_without_duplicating():
     from mas.ctl.manifest.mas_agent_merge import apply_agency_entry_overlay
 

--- a/docs/manifests/agent.md
+++ b/docs/manifests/agent.md
@@ -144,6 +144,17 @@ context:
     ref: "./prompts/broker.md"
 ```
 
+Array of fragments — resolved and joined with newlines. Lets an overlay
+append (or remove) one fragment via `context: {role: {"$op": {"add": [...]}}}`
+without restating the rest of the prompt (see overlay.md#merge-semantics):
+
+```yaml
+context:
+  role:
+    - "You are a telemetry analyst…"
+    - ref: "./prompts/escalation.md"
+```
+
 ---
 
 ## Schema source

--- a/docs/manifests/overlay.md
+++ b/docs/manifests/overlay.md
@@ -63,10 +63,15 @@ restating the rest of the base prompt:
 ```yaml
 patch:
   context:
-    role: {"$op": {"add": ["Escalate P1 incidents immediately."]}}
-    # remove: ["Escalate P1 incidents immediately."]
-    # replace: ["Whole new role text."]
-    # clear: true
+    role:
+      $op:
+        add:
+          - "Escalate P1 incidents immediately."
+        # remove:
+        #   - "Escalate P1 incidents immediately."
+        # replace:
+        #   - "Whole new role text."
+        # clear: true
 ```
 
 ---

--- a/docs/manifests/overlay.md
+++ b/docs/manifests/overlay.md
@@ -54,6 +54,21 @@ Patches use RFC 7396 JSON merge; list fields such as `tools` accept an explicit
 `{"$op": {replace|add|remove|clear: [...]}}` form (handled explicitly by the
 runtime) alongside plain-list implicit replace.
 
+`context` (prompt/role text) gets the same `$op` sugar, but per chunk name.
+Each `spec.context.<key>` value may be a plain string/`{ref}` (implicit full
+replace, same as always) or a list of fragments — a `$op` patch operates on
+that fragment list, so an overlay can append or drop one line without
+restating the rest of the base prompt:
+
+```yaml
+patch:
+  context:
+    role: {"$op": {"add": ["Escalate P1 incidents immediately."]}}
+    # remove: ["Escalate P1 incidents immediately."]
+    # replace: ["Whole new role text."]
+    # clear: true
+```
+
 ---
 
 ## Experiment linkage

--- a/docs/schemas/runtime/fragments/context-chunk.schema.yaml
+++ b/docs/schemas/runtime/fragments/context-chunk.schema.yaml
@@ -13,6 +13,11 @@ description: >
 
   Object form — {ref: path} always loads the file; raises at bootstrap when the
   path is missing.
+
+  Array form — a list of fragments (each a plain string or {ref: path}); the
+  resolved chunk text is the fragments joined with newlines. This lets an overlay
+  add or remove one fragment (via the `$op` sugar on overlay context patches)
+  without having to restate the rest of the chunk's text.
 oneOf:
   - type: string
   - type: object
@@ -24,3 +29,16 @@ oneOf:
         description: >
           File path relative to the agent manifest directory. Must exist;
           missing refs fail bootstrap with ContextRefNotFoundError.
+  - type: array
+    items:
+      oneOf:
+        - type: string
+        - type: object
+          additionalProperties: false
+          required: [ref]
+          properties:
+            ref:
+              type: string
+              description: >
+                File path relative to the agent manifest directory. Must exist;
+                missing refs fail bootstrap with ContextRefNotFoundError.

--- a/docs/schemas/runtime/fragments/overlay-agent-patch.schema.yaml
+++ b/docs/schemas/runtime/fragments/overlay-agent-patch.schema.yaml
@@ -34,7 +34,10 @@ properties:
   params:
     $ref: "../agent.schema.yaml#/properties/spec/properties/params"
   context:
-    $ref: "../agent.schema.yaml#/properties/spec/properties/context"
+    # Not a plain $ref: overlay-time patches accept the {"$op": {...}} sugar
+    # per chunk name (add/remove/replace/clear a chunk's fragment list) --
+    # a genuine shape difference from the base schema's plain ContextChunk map.
+    $ref: "./overlay-collection-ops-context.schema.yaml"
   memory:
     $ref: "../agent.schema.yaml#/properties/spec/properties/memory"
   working_memory:

--- a/docs/schemas/runtime/fragments/overlay-collection-ops-context.schema.yaml
+++ b/docs/schemas/runtime/fragments/overlay-collection-ops-context.schema.yaml
@@ -1,0 +1,60 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+$schema: "https://json-schema.org/draft-07/schema#"
+title: OverlayContextCollectionOps
+description: >
+  Per-chunk overlay patch for spec.context. Each chunk name maps either to a
+  plain ContextChunk value (implicit replace -- same as the base schema) or to
+  `$op` sugar operating on that chunk's fragment list (replace/add/remove/clear),
+  the same vocabulary list-valued fields such as spec.tools already use. `add`
+  lets an overlay append one fragment to an existing chunk (e.g. spec.context.role)
+  without restating the rest of its text.
+type: object
+additionalProperties:
+  oneOf:
+    - $ref: "./context-chunk.schema.yaml"
+    - type: object
+      additionalProperties: false
+      required: [$op]
+      properties:
+        $op:
+          type: object
+          additionalProperties: false
+          minProperties: 1
+          properties:
+            replace:
+              type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: object
+                    additionalProperties: false
+                    required: [ref]
+                    properties:
+                      ref:
+                        type: string
+            add:
+              type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: object
+                    additionalProperties: false
+                    required: [ref]
+                    properties:
+                      ref:
+                        type: string
+            remove:
+              type: array
+              items:
+                oneOf:
+                  - type: string
+                  - type: object
+                    additionalProperties: false
+                    required: [ref]
+                    properties:
+                      ref:
+                        type: string
+            clear:
+              type: boolean
+              const: true

--- a/runtime/src/mas/runtime/boundary/context/manifest_context.py
+++ b/runtime/src/mas/runtime/boundary/context/manifest_context.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -51,7 +52,13 @@ def _is_probeable_path_candidate(text: str) -> bool:
 
 
 def resolve_context_chunk(value: Any, *, base_dir: Path) -> str | None:
-    """Expand one spec.context entry to prompt text."""
+    """Expand one spec.context entry to prompt text.
+
+    A list value is a sequence of fragments (each itself a string or {ref}),
+    resolved individually and joined with newlines -- lets a chunk be composed
+    from multiple pieces (e.g. a base fragment plus one an overlay appended via
+    merge_context_chunk) instead of one monolithic string.
+    """
     if isinstance(value, str):
         text = value.strip()
         if not text:
@@ -76,6 +83,17 @@ def resolve_context_chunk(value: Any, *, base_dir: Path) -> str | None:
         ref = value.get("ref")
         if isinstance(ref, str) and ref.strip():
             return _read_context_file((base_dir / ref.strip()).resolve())
+    elif isinstance(value, list):
+        fragments: list[str] = []
+        for item in value:
+            if isinstance(item, list):
+                raise ContextChunkError(
+                    f"unsupported context chunk value: nested array {item!r}"
+                )
+            text = resolve_context_chunk(item, base_dir=base_dir)
+            if text:
+                fragments.append(text)
+        return "\n".join(fragments) if fragments else None
     raise ContextChunkError(f"unsupported context chunk value: {value!r}")
 
 
@@ -94,3 +112,67 @@ def context_chunks_from_spec(spec: dict[str, Any], *, base_dir: Path) -> list[st
         if text:
             out.append(f"[{key}] {text}")
     return out
+
+
+_CONTEXT_CHUNK_OP_KEYS = {"replace", "add", "remove", "clear"}
+
+
+def _context_chunk_ops(value: Any) -> dict[str, Any] | None:
+    """Recognize the `{"$op": {...}}` (or bare) sugar form on a chunk patch value."""
+    if isinstance(value, dict) and isinstance(value.get("$op"), dict):
+        value = value["$op"]
+    if not isinstance(value, dict):
+        return None
+    if not (set(value) & _CONTEXT_CHUNK_OP_KEYS):
+        return None
+    return value
+
+
+def _as_fragment_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    return [value]
+
+
+def merge_context_chunk(existing: Any, incoming: Any) -> Any:
+    """Merge one spec.context.<key> overlay patch value onto its base value.
+
+    A plain value (string/{ref}/list) fully replaces the base chunk -- implicit
+    replace ergonomics, consistent with every other overlay merge strategy in
+    this repo. A `{"$op": {replace|add|remove|clear}}` value instead operates on
+    the base chunk's fragment list (coercing a scalar base value to a one-item
+    list first), so an overlay can add or remove a single fragment -- e.g.
+    append one sentence to spec.context.role -- without restating the rest.
+    """
+    ops = _context_chunk_ops(incoming)
+    if ops is None:
+        return deepcopy(incoming)
+
+    result = [] if ops.get("clear") is True else _as_fragment_list(existing)
+
+    if "replace" in ops:
+        result = list(ops.get("replace") or [])
+
+    if "remove" in ops:
+        to_remove = list(ops.get("remove") or [])
+        result = [item for item in result if item not in to_remove]
+
+    if "add" in ops:
+        for item in list(ops.get("add") or []):
+            if item not in result:
+                result.append(item)
+
+    return result
+
+
+def merge_context_map(existing: Any, incoming: dict[str, Any]) -> dict[str, Any]:
+    """Merge an overlay's spec.context patch onto the base spec.context map."""
+    merged = deepcopy(existing) if isinstance(existing, dict) else {}
+    for key, value in incoming.items():
+        if value is None:
+            merged.pop(key, None)
+            continue
+        merged[key] = merge_context_chunk(merged.get(key), value)
+    return merged

--- a/runtime/src/mas/runtime/boundary/context/manifest_context.py
+++ b/runtime/src/mas/runtime/boundary/context/manifest_context.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -56,8 +55,9 @@ def resolve_context_chunk(value: Any, *, base_dir: Path) -> str | None:
 
     A list value is a sequence of fragments (each itself a string or {ref}),
     resolved individually and joined with newlines -- lets a chunk be composed
-    from multiple pieces (e.g. a base fragment plus one an overlay appended via
-    merge_context_chunk) instead of one monolithic string.
+    from multiple pieces (e.g. a base fragment plus one an overlay appended,
+    see mas.ctl.overlay.merge.merge_context_chunk) instead of one monolithic
+    string.
     """
     if isinstance(value, str):
         text = value.strip()
@@ -112,67 +112,3 @@ def context_chunks_from_spec(spec: dict[str, Any], *, base_dir: Path) -> list[st
         if text:
             out.append(f"[{key}] {text}")
     return out
-
-
-_CONTEXT_CHUNK_OP_KEYS = {"replace", "add", "remove", "clear"}
-
-
-def _context_chunk_ops(value: Any) -> dict[str, Any] | None:
-    """Recognize the `{"$op": {...}}` (or bare) sugar form on a chunk patch value."""
-    if isinstance(value, dict) and isinstance(value.get("$op"), dict):
-        value = value["$op"]
-    if not isinstance(value, dict):
-        return None
-    if not (set(value) & _CONTEXT_CHUNK_OP_KEYS):
-        return None
-    return value
-
-
-def _as_fragment_list(value: Any) -> list[Any]:
-    if value is None:
-        return []
-    if isinstance(value, list):
-        return list(value)
-    return [value]
-
-
-def merge_context_chunk(existing: Any, incoming: Any) -> Any:
-    """Merge one spec.context.<key> overlay patch value onto its base value.
-
-    A plain value (string/{ref}/list) fully replaces the base chunk -- implicit
-    replace ergonomics, consistent with every other overlay merge strategy in
-    this repo. A `{"$op": {replace|add|remove|clear}}` value instead operates on
-    the base chunk's fragment list (coercing a scalar base value to a one-item
-    list first), so an overlay can add or remove a single fragment -- e.g.
-    append one sentence to spec.context.role -- without restating the rest.
-    """
-    ops = _context_chunk_ops(incoming)
-    if ops is None:
-        return deepcopy(incoming)
-
-    result = [] if ops.get("clear") is True else _as_fragment_list(existing)
-
-    if "replace" in ops:
-        result = list(ops.get("replace") or [])
-
-    if "remove" in ops:
-        to_remove = list(ops.get("remove") or [])
-        result = [item for item in result if item not in to_remove]
-
-    if "add" in ops:
-        for item in list(ops.get("add") or []):
-            if item not in result:
-                result.append(item)
-
-    return result
-
-
-def merge_context_map(existing: Any, incoming: dict[str, Any]) -> dict[str, Any]:
-    """Merge an overlay's spec.context patch onto the base spec.context map."""
-    merged = deepcopy(existing) if isinstance(existing, dict) else {}
-    for key, value in incoming.items():
-        if value is None:
-            merged.pop(key, None)
-            continue
-        merged[key] = merge_context_chunk(merged.get(key), value)
-    return merged

--- a/runtime/tests/test_manifest_context.py
+++ b/runtime/tests/test_manifest_context.py
@@ -10,8 +10,6 @@ from mas.runtime.boundary.context.manifest_context import (
     ContextChunkError,
     ContextRefNotFoundError,
     context_chunks_from_spec,
-    merge_context_chunk,
-    merge_context_map,
     resolve_context_chunk,
     routing_description_from_agent,
 )
@@ -118,56 +116,3 @@ def test_context_chunks_from_spec_resolves_array_chunk(tmp_path: Path):
     spec = {"context": {"role": ["You are a triage agent.", "Be concise."]}}
     chunks = context_chunks_from_spec(spec, base_dir=tmp_path)
     assert chunks == ["[role] You are a triage agent.\nBe concise."]
-
-
-def test_merge_context_chunk_add_appends_without_duplicating():
-    merged = merge_context_chunk("You are a triage agent.", {"$op": {"add": ["Be concise."]}})
-    assert merged == ["You are a triage agent.", "Be concise."]
-
-
-def test_merge_context_chunk_add_is_idempotent():
-    merged = merge_context_chunk(["a", "b"], {"$op": {"add": ["b", "c"]}})
-    assert merged == ["a", "b", "c"]
-
-
-def test_merge_context_chunk_remove():
-    merged = merge_context_chunk(["a", "b", "c"], {"$op": {"remove": ["b"]}})
-    assert merged == ["a", "c"]
-
-
-def test_merge_context_chunk_replace():
-    merged = merge_context_chunk(["a", "b"], {"$op": {"replace": ["z"]}})
-    assert merged == ["z"]
-
-
-def test_merge_context_chunk_clear():
-    merged = merge_context_chunk(["a", "b"], {"$op": {"clear": True}})
-    assert merged == []
-
-
-def test_merge_context_chunk_plain_string_value_replaces():
-    """No `$op` sugar -- implicit full replace, same ergonomics as list_ops."""
-    assert merge_context_chunk("old role", "new role") == "new role"
-
-
-def test_merge_context_chunk_plain_array_value_replaces():
-    """A plain array (no `$op`) is also an implicit full replace, not an add --
-    `$op` is what opts into fragment-level merging; a bare list is a new chunk
-    value, same as a bare string or {ref} would be."""
-    merged = merge_context_chunk(["a", "b"], ["c", "d"])
-    assert merged == ["c", "d"]
-
-
-def test_merge_context_chunk_plain_array_replaces_existing_string_chunk():
-    merged = merge_context_chunk("old role", ["fragment one", "fragment two"])
-    assert merged == ["fragment one", "fragment two"]
-
-
-def test_merge_context_map_adds_new_key_and_patches_existing():
-    base = {"role": "You are a triage agent."}
-    patch = {"role": {"$op": {"add": ["Be concise."]}}, "intent": "Stay on task."}
-    merged = merge_context_map(base, patch)
-    assert merged == {
-        "role": ["You are a triage agent.", "Be concise."],
-        "intent": "Stay on task.",
-    }

--- a/runtime/tests/test_manifest_context.py
+++ b/runtime/tests/test_manifest_context.py
@@ -145,9 +145,22 @@ def test_merge_context_chunk_clear():
     assert merged == []
 
 
-def test_merge_context_chunk_plain_value_replaces():
+def test_merge_context_chunk_plain_string_value_replaces():
     """No `$op` sugar -- implicit full replace, same ergonomics as list_ops."""
     assert merge_context_chunk("old role", "new role") == "new role"
+
+
+def test_merge_context_chunk_plain_array_value_replaces():
+    """A plain array (no `$op`) is also an implicit full replace, not an add --
+    `$op` is what opts into fragment-level merging; a bare list is a new chunk
+    value, same as a bare string or {ref} would be."""
+    merged = merge_context_chunk(["a", "b"], ["c", "d"])
+    assert merged == ["c", "d"]
+
+
+def test_merge_context_chunk_plain_array_replaces_existing_string_chunk():
+    merged = merge_context_chunk("old role", ["fragment one", "fragment two"])
+    assert merged == ["fragment one", "fragment two"]
 
 
 def test_merge_context_map_adds_new_key_and_patches_existing():

--- a/runtime/tests/test_manifest_context.py
+++ b/runtime/tests/test_manifest_context.py
@@ -10,6 +10,8 @@ from mas.runtime.boundary.context.manifest_context import (
     ContextChunkError,
     ContextRefNotFoundError,
     context_chunks_from_spec,
+    merge_context_chunk,
+    merge_context_map,
     resolve_context_chunk,
     routing_description_from_agent,
 )
@@ -83,3 +85,76 @@ def test_resolve_context_chunk_long_inline_role_without_slash(tmp_path: Path):
         "Always include your reasoning before calling an agent or producing a final answer."
     )
     assert resolve_context_chunk(role, base_dir=tmp_path) == role
+
+
+def test_resolve_context_chunk_array_joins_fragments(tmp_path: Path):
+    value = ["You are a triage agent.", "Always cite your sources."]
+    assert (
+        resolve_context_chunk(value, base_dir=tmp_path)
+        == "You are a triage agent.\nAlways cite your sources."
+    )
+
+
+def test_resolve_context_chunk_array_mixes_inline_and_ref(tmp_path: Path):
+    escalation = tmp_path / "escalation.md"
+    escalation.write_text("Escalate P1 incidents immediately.", encoding="utf-8")
+    value = ["You are a triage agent.", {"ref": "escalation.md"}]
+    assert resolve_context_chunk(value, base_dir=tmp_path) == (
+        "You are a triage agent.\nEscalate P1 incidents immediately."
+    )
+
+
+def test_resolve_context_chunk_array_missing_ref_raises(tmp_path: Path):
+    with pytest.raises(ContextRefNotFoundError, match="missing.md"):
+        resolve_context_chunk(["ok", {"ref": "missing.md"}], base_dir=tmp_path)
+
+
+def test_resolve_context_chunk_nested_array_raises(tmp_path: Path):
+    with pytest.raises(ContextChunkError, match="nested array"):
+        resolve_context_chunk(["ok", ["nested"]], base_dir=tmp_path)
+
+
+def test_context_chunks_from_spec_resolves_array_chunk(tmp_path: Path):
+    spec = {"context": {"role": ["You are a triage agent.", "Be concise."]}}
+    chunks = context_chunks_from_spec(spec, base_dir=tmp_path)
+    assert chunks == ["[role] You are a triage agent.\nBe concise."]
+
+
+def test_merge_context_chunk_add_appends_without_duplicating():
+    merged = merge_context_chunk("You are a triage agent.", {"$op": {"add": ["Be concise."]}})
+    assert merged == ["You are a triage agent.", "Be concise."]
+
+
+def test_merge_context_chunk_add_is_idempotent():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"add": ["b", "c"]}})
+    assert merged == ["a", "b", "c"]
+
+
+def test_merge_context_chunk_remove():
+    merged = merge_context_chunk(["a", "b", "c"], {"$op": {"remove": ["b"]}})
+    assert merged == ["a", "c"]
+
+
+def test_merge_context_chunk_replace():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"replace": ["z"]}})
+    assert merged == ["z"]
+
+
+def test_merge_context_chunk_clear():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"clear": True}})
+    assert merged == []
+
+
+def test_merge_context_chunk_plain_value_replaces():
+    """No `$op` sugar -- implicit full replace, same ergonomics as list_ops."""
+    assert merge_context_chunk("old role", "new role") == "new role"
+
+
+def test_merge_context_map_adds_new_key_and_patches_existing():
+    base = {"role": "You are a triage agent."}
+    patch = {"role": {"$op": {"add": ["Be concise."]}}, "intent": "Stay on task."}
+    merged = merge_context_map(base, patch)
+    assert merged == {
+        "role": ["You are a triage agent.", "Be concise."],
+        "intent": "Stay on task.",
+    }

--- a/runtime/tests/test_overlay_merge.py
+++ b/runtime/tests/test_overlay_merge.py
@@ -79,6 +79,14 @@ def test_merge_context_plain_value_still_fully_replaces_chunk():
     assert merged["spec"]["context"]["role"] == "new role"
 
 
+def test_merge_context_plain_array_still_fully_replaces_chunk():
+    """A plain array patch (no `$op`) replaces the chunk wholesale, same as a
+    plain string always has -- only `$op` opts into add/remove fragment merging."""
+    base = {"spec": {"context": {"role": ["a", "b"]}}}
+    merged = merge_overlay(base, _overlay({"context": {"role": ["c", "d"]}}))
+    assert merged["spec"]["context"]["role"] == ["c", "d"]
+
+
 def test_merge_skills():
     base = {"spec": {"skills": ["s1"]}}
     merged = merge_overlay(base, _overlay({"skills": {"$op": {"add": ["s1", "s2"]}}}))

--- a/runtime/tests/test_overlay_merge.py
+++ b/runtime/tests/test_overlay_merge.py
@@ -2,7 +2,14 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Overlay merge tests."""
 
-from mas.ctl.overlay.merge import OverlayTargetError, apply_merge_patch, merge_overlay, overlay_runtime_semantics
+from mas.ctl.overlay.merge import (
+    OverlayTargetError,
+    apply_merge_patch,
+    merge_context_chunk,
+    merge_context_map,
+    merge_overlay,
+    overlay_runtime_semantics,
+)
 
 
 def _overlay(patch: dict, *, name: str = "test", target_kind: str = "Agent") -> dict:
@@ -85,6 +92,59 @@ def test_merge_context_plain_array_still_fully_replaces_chunk():
     base = {"spec": {"context": {"role": ["a", "b"]}}}
     merged = merge_overlay(base, _overlay({"context": {"role": ["c", "d"]}}))
     assert merged["spec"]["context"]["role"] == ["c", "d"]
+
+
+def test_merge_context_chunk_add_appends_without_duplicating():
+    merged = merge_context_chunk("You are a triage agent.", {"$op": {"add": ["Be concise."]}})
+    assert merged == ["You are a triage agent.", "Be concise."]
+
+
+def test_merge_context_chunk_add_is_idempotent():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"add": ["b", "c"]}})
+    assert merged == ["a", "b", "c"]
+
+
+def test_merge_context_chunk_remove():
+    merged = merge_context_chunk(["a", "b", "c"], {"$op": {"remove": ["b"]}})
+    assert merged == ["a", "c"]
+
+
+def test_merge_context_chunk_replace():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"replace": ["z"]}})
+    assert merged == ["z"]
+
+
+def test_merge_context_chunk_clear():
+    merged = merge_context_chunk(["a", "b"], {"$op": {"clear": True}})
+    assert merged == []
+
+
+def test_merge_context_chunk_plain_string_value_replaces():
+    """No `$op` sugar -- implicit full replace, same ergonomics as list_ops."""
+    assert merge_context_chunk("old role", "new role") == "new role"
+
+
+def test_merge_context_chunk_plain_array_value_replaces():
+    """A plain array (no `$op`) is also an implicit full replace, not an add --
+    `$op` is what opts into fragment-level merging; a bare list is a new chunk
+    value, same as a bare string or {ref} would be."""
+    merged = merge_context_chunk(["a", "b"], ["c", "d"])
+    assert merged == ["c", "d"]
+
+
+def test_merge_context_chunk_plain_array_replaces_existing_string_chunk():
+    merged = merge_context_chunk("old role", ["fragment one", "fragment two"])
+    assert merged == ["fragment one", "fragment two"]
+
+
+def test_merge_context_map_adds_new_key_and_patches_existing():
+    base = {"role": "You are a triage agent."}
+    patch = {"role": {"$op": {"add": ["Be concise."]}}, "intent": "Stay on task."}
+    merged = merge_context_map(base, patch)
+    assert merged == {
+        "role": ["You are a triage agent.", "Be concise."],
+        "intent": "Stay on task.",
+    }
 
 
 def test_merge_skills():

--- a/runtime/tests/test_overlay_merge.py
+++ b/runtime/tests/test_overlay_merge.py
@@ -44,10 +44,39 @@ def test_merge_context_dict():
     assert merged["spec"]["context"] == {"role": "a", "intent": "b"}
 
 
-def test_merge_context_list():
-    base = {"spec": {"context": ["a"]}}
-    merged = merge_overlay(base, _overlay({"context": ["b"]}))
-    assert merged["spec"]["context"] == ["a", "b"]
+def test_merge_context_op_add_appends_without_duplicating_base_text():
+    base = {"spec": {"context": {"role": "You are a triage agent."}}}
+    merged = merge_overlay(
+        base, _overlay({"context": {"role": {"$op": {"add": ["Escalate P1s immediately."]}}}})
+    )
+    assert merged["spec"]["context"]["role"] == [
+        "You are a triage agent.",
+        "Escalate P1s immediately.",
+    ]
+
+
+def test_merge_context_op_remove():
+    base = {"spec": {"context": {"role": ["a", "b", "c"]}}}
+    merged = merge_overlay(base, _overlay({"context": {"role": {"$op": {"remove": ["b"]}}}}))
+    assert merged["spec"]["context"]["role"] == ["a", "c"]
+
+
+def test_merge_context_op_replace():
+    base = {"spec": {"context": {"role": ["a", "b"]}}}
+    merged = merge_overlay(base, _overlay({"context": {"role": {"$op": {"replace": ["z"]}}}}))
+    assert merged["spec"]["context"]["role"] == ["z"]
+
+
+def test_merge_context_op_clear():
+    base = {"spec": {"context": {"role": ["a", "b"]}}}
+    merged = merge_overlay(base, _overlay({"context": {"role": {"$op": {"clear": True}}}}))
+    assert merged["spec"]["context"]["role"] == []
+
+
+def test_merge_context_plain_value_still_fully_replaces_chunk():
+    base = {"spec": {"context": {"role": "old role"}}}
+    merged = merge_overlay(base, _overlay({"context": {"role": "new role"}}))
+    assert merged["spec"]["context"]["role"] == "new role"
 
 
 def test_merge_skills():


### PR DESCRIPTION
## The problem

Agent prompts (the `role`, `intent`, etc. text under `spec.context` in an agent
manifest) are one indivisible value today — a plain string, or a `{ref: path}`
pointer to a file, but never composable pieces. Overlays are the mechanism for
tweaking an agent for a specific scenario/deployment without editing the base
manifest — but because a prompt chunk is one value, an overlay that wants to
add even a single sentence to an existing prompt has to paste in the *entire*
original prompt text plus the new sentence. Otherwise the overlay just
replaces the whole prompt, silently dropping everything that was there before.

That's exactly the pain point that prompted this change: teams want to add
one line to a base prompt from an overlay, and today the only way to do that
is to copy-paste the base prompt into every overlay that touches it — so any
future edit to the base prompt has to be repeated in every overlay too.

## The fix

A prompt chunk can now optionally be written as a **list of pieces**
("fragments") instead of one string:

```yaml
# agent manifest
spec:
  context:
    role:
      - "You are a triage agent."
      - "Always cite your sources."
```

An overlay can then add or remove a single fragment using the same `$op`
syntax already used elsewhere in this repo for tool/skill lists
(see e.g. `docs/tutorials/01-building-an-agent/overlays/tools.yaml`,
`library-samples/overlays/shell-tool.yaml`):

```yaml
# overlay
spec:
  patch:
    context:
      role:
        $op:
          add:
            - "Escalate P1 incidents immediately."
```

Result: the base prompt's existing fragments are untouched, and the overlay's
line is appended after them —

```
role -> [
  "You are a triage agent.",
  "Always cite your sources.",
  "Escalate P1 incidents immediately.",
]
```

`remove`, `replace`, and `clear` work the same way. A plain (non-`$op`) overlay
value — whether a string or a bare array — still fully **replaces** the chunk,
exactly like today: `$op` is what opts into fragment-level add/remove, a bare
value is always a wholesale replacement. Nothing changes for existing
manifests/overlays that don't use this.

## Where this applies

There are two places an agent's `spec.context` can be overlaid, and both now
behave the same way:
- a standalone `kind: Overlay` document (`ctl/overlay/merge.py`)
- a per-agent overlay embedded directly in a MAS manifest's `agency.agents[]`
  (`ctl/manifest/mas_agent_merge.py`)

Both were previously doing an unconditional "overlay's chunk replaces the
base chunk" merge; both now go through the same shared merge helpers in
`manifest_context.py`.

## Test plan
- [x] `runtime/tests/test_manifest_context.py` — array chunk resolution, `{ref}`/inline mixes, missing-ref and nested-array errors, merge helper unit tests, plain string/array patches still fully replace
- [x] `runtime/tests/test_overlay_merge.py` — `$op` add/remove/replace/clear on `spec.context`, plain string/array patches still fully replace (not add)
- [x] `ctl/tests/test_bootstrap_context.py` — array chunk resolves to one joined `[role] ...` line in injected context
- [x] `ctl/tests/test_mas_agent_merge.py` — agency-embedded context overlay gets the same `$op` ergonomics, plain array patch still fully replaces (not add)
- [x] Full repo test suite (`runtime/tests`, `ctl/tests`, `tests`) — no new failures; the handful of pre-existing failures were confirmed present on the unmodified baseline too
- [x] End-to-end schema validation of a sample overlay using the new `$op` sugar via `mas.ctl.validate.validator.validate_file`
