### PR TITLE
fix(tests): correct stale paths, assertions, and gaps found via a full-suite sweep

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,7 +86,7 @@ tasks:
     desc: "Dry-run paper lab experiments (design-space, lifecycle-control, extensions)"
     deps: [install-dev]
     cmds:
-      - "{{.VENV}}/pytest tests/test_outshift_reproduction.py -q --tb=line -k 'test_experiment_dry_run and labs/'"
+      - "{{.VENV}}/pytest tests/test_reproduction.py -q --tb=line -k 'test_experiment_dry_run and labs/'"
 
   reproduce:
     desc: "Reproduce all paper experiments. Uses content-addressed trace cache — re-runs complete in seconds."
@@ -100,7 +100,7 @@ tasks:
     desc: "Dry-run paper + tutorial experiments (see tests/fixtures/reproduction/experiments.yaml)"
     deps: [install-dev]
     cmds:
-      - "{{.VENV}}/pytest tests/test_outshift_reproduction.py -q --tb=line -k test_experiment_dry_run"
+      - "{{.VENV}}/pytest tests/test_reproduction.py -q --tb=line -k test_experiment_dry_run"
 
   verify-functional:
     desc: "Functional / integration tests (lab smoke + golden runs + tutorial CLI tests)"
@@ -138,7 +138,7 @@ tasks:
     deps: [install-dev]
     cmds:
       - python3 scripts/gen_docs.py --check
-      - "{{.VENV}}/pytest tests/test_outshift_reproduction.py tests/test_hitl_tool_gate.py -q --tb=line"
+      - "{{.VENV}}/pytest tests/test_reproduction.py tests/test_hitl_tool_gate.py -q --tb=line"
 
   verify-ctl-env:
     desc: "mas-ctl resolves from this repo .venv"

--- a/ctl/tests/test_deployment_runtime_id.py
+++ b/ctl/tests/test_deployment_runtime_id.py
@@ -11,7 +11,7 @@ from mas.ctl.deployment.runtime_id import DEFAULT_RUNTIME_ID
 
 
 def test_resolve_default_runtime_from_tutorial_deployment():
-    root = Path(__file__).resolve().parents[3]
+    root = Path(__file__).resolve().parents[2]
     t01 = root / "docs" / "tutorials" / "01-building-an-agent"
     if not t01.is_dir():
         pytest.skip("tutorial bundle not present")
@@ -20,7 +20,7 @@ def test_resolve_default_runtime_from_tutorial_deployment():
 
 
 def test_cli_override_wins():
-    root = Path(__file__).resolve().parents[3]
+    root = Path(__file__).resolve().parents[2]
     t01 = root / "docs" / "tutorials" / "01-building-an-agent"
     if not t01.is_dir():
         pytest.skip("tutorial bundle not present")

--- a/labs/design-space.lab/03-collaboration-patterns/experiment-topology-definitions-smoke.yaml
+++ b/labs/design-space.lab/03-collaboration-patterns/experiment-topology-definitions-smoke.yaml
@@ -11,12 +11,18 @@ experiment:
   default_flavour: local
 
   applications:
-    - app: trip-planner-topo-moderator-broker
-    - app: trip-planner-topo-parallel
-    - app: trip-planner-topo-linear-pipeline
-    - app: trip-planner-topo-supervised
-    - app: trip-planner-topo-verifier
-    - app: trip-planner-topo-single-agent
+    # trip-planner-topo-* names are declared in library-samples/library.yaml,
+    # but as direct .mas.yaml file paths, not app *directories* -- the only
+    # shape discover_apps() registers from a library manifest (see
+    # runtime/src/mas/library_catalog.py:_discover_apps_from_manifest). Use
+    # manifest: (the schema's own direct-path alternative to app:) with the
+    # samples: library scheme instead of a ../../../ relative path.
+    - manifest: samples:apps/trip-planner/mas-topologies/moderator-broker.mas.yaml
+    - manifest: samples:apps/trip-planner/mas-topologies/parallel.mas.yaml
+    - manifest: samples:apps/trip-planner/mas-topologies/linear-pipeline.mas.yaml
+    - manifest: samples:apps/trip-planner/mas-topologies/supervised.mas.yaml
+    - manifest: samples:apps/trip-planner/mas-topologies/verifier.mas.yaml
+    - manifest: samples:apps/trip-planner/mas-topologies/single-agent.mas.yaml
 
   scenarios:
     - id: baseline

--- a/library-samples/tools/README.md
+++ b/library-samples/tools/README.md
@@ -16,6 +16,9 @@ Dataset policy:
 - neither `mas-runtime` nor `mas-ctl` should coordinate fixtures through
   hidden sidecars or implicit files for this example
 
+Related docs: [lab/docs/labs-quickstart.md](../../lab/docs/labs-quickstart.md) ·
+[lab/docs/labs-going-further.md](../../lab/docs/labs-going-further.md).
+
 Files:
 
 - `query_graph_database.py` — route topology and connection search

--- a/tests/fixtures/reproduction/experiments.yaml
+++ b/tests/fixtures/reproduction/experiments.yaml
@@ -1,7 +1,7 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
 # Experiments that must pass `mas-lab benchmark run <path> --dry-run`.
-# Used by tests/test_outshift_reproduction.py and task verify-reproduce.
+# Used by tests/test_reproduction.py and task verify-reproduce.
 #
 # Add new paper labs / tutorial experiments here when they ship.
 
@@ -9,11 +9,16 @@ experiments:
   # Paper labs (design-space §5.1–5.3)
   - labs/design-space.lab/01-design-patterns/experiment.yaml
   - labs/design-space.lab/02-topologies/experiment.yaml
+  - labs/design-space.lab/03-collaboration-patterns/experiment.yaml
+  - labs/design-space.lab/03-collaboration-patterns/experiment-smoke.yaml
   - labs/lifecycle-control.lab/experiment.yaml
   - labs/extensions.lab/experiment.yaml
   - labs/lifecycle-control.lab/02-bit-exactness/experiment.yaml
   - labs/lifecycle-control.lab/experiment-whatif-smoke.yaml
   - labs/extensions.lab/experiment-fact-recall-smoke.yaml
+  # 03-collaboration-patterns dev fixtures (not paper-reported results)
+  - labs/design-space.lab/03-collaboration-patterns/experiment-sequential-demo.yaml
+  - labs/design-space.lab/03-collaboration-patterns/experiment-topology-definitions-smoke.yaml
   # CI smoke + golden capture paths
   - tests/fixtures/lab-smoke/experiment.yaml
   - tests/fixtures/lab-smoke/design-space-patterns.yaml

--- a/tests/test_ctl_runtime_smoke.py
+++ b/tests/test_ctl_runtime_smoke.py
@@ -30,9 +30,9 @@ def test_workspace_infra_refs_from_sample_workspace():
     from mas.ctl.workspace.config import WorkspaceConfig
 
     repo = Path(__file__).resolve().parents[1]
-    sample = repo / "examples"
+    sample = repo / "examples" / "sample-workspace"
     assert (sample / "config.yaml").is_file()
-    ws = WorkspaceConfig.load(repo / "docs/tutorials/01-building-an-agent")
+    ws = WorkspaceConfig.load(sample)
     assert ws.found
     infra = resolve_infra_refs(["standard:mock-llm"], anchor=repo, workspace=ws)
     assert infra.llm_proxy.get("provider") == "mock" or "mock" in str(infra.refs).lower()

--- a/tests/test_hitl_turn_commit.py
+++ b/tests/test_hitl_turn_commit.py
@@ -60,7 +60,17 @@ def test_submit_hitl_commits_tool_trajectory_for_next_turn() -> None:
 
     pending = controller.run_turn("Who is current POTUS ?", auto_hitl=False)
     assert pending.awaiting_hitl
-    assert not instance.driver.ctx.committed_messages
+    # _finalize_turn folds working memory into committed history even while
+    # paused at HITL (see its own docstring, and
+    # docs/design/working-memory-compaction.md): the tool call that already
+    # ran this turn must not be silently dropped if the next turn's
+    # note_user_input() clears working memory before HITL resolves.
+    early_committed = instance.driver.ctx.committed_messages
+    assert any(
+        m.get("role") == "user" and m.get("content") == "Who is current POTUS ?"
+        for m in early_committed
+    )
+    assert any(m.get("role") == "assistant" and m.get("tool_calls") for m in early_committed)
 
     request = pending.trace.hitl_requests[-1]
     done = controller.submit_hitl(

--- a/tests/test_lab_quickstart_links.py
+++ b/tests/test_lab_quickstart_links.py
@@ -9,7 +9,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 TARGETS = [
     REPO_ROOT / "lab" / "README.md",
-    REPO_ROOT / "library-samples" / "apps" / "trip-planner" / "tools" / "README.md",
+    REPO_ROOT / "library-samples" / "tools" / "README.md",
 ]
 
 

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,6 +1,6 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-"""Outshift-open reproduction gate — dry-run all declared experiments + doc checks."""
+"""Reproduction gate — dry-run all declared experiments + doc checks."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
- workspace smoke test: load the real sample workspace, not a template
- HITL commit-timing test: assert the actual (intentional) early-commit state
- quickstart-links test + library-samples/tools README: point at where the
  file lives now, restore the dropped labs-quickstart/going-further links
- reproduction manifest: register 03-collaboration-patterns' experiments;
  fix its topology refs (manifest:samples: instead of unresolvable app: names)
- runtime_id tests: parents[2], not parents[3] -- both were always skipping
- test_reproduction.py: drop the org name from the reproduction-gate test