### PR TITLE
feat: experiment overlays (-x flag) and benchmark correctness fixes

### DIFF
--- a/lab/components/bench/src/mas/lab/benchmark/engine.py
+++ b/lab/components/bench/src/mas/lab/benchmark/engine.py
@@ -1,14 +1,14 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 """Benchmark engine — MAS experiments only; no CLI concerns."""
 
-from dataclasses import dataclass, field
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,7 @@ class BenchmarkRunOptions:
     strategy: str | None = None
     step_overrides: list = field(default_factory=list)
     pipeline_attachments: list = field(default_factory=list)
+    experiment_overlays: list = field(default_factory=list)
     clean_stale: bool | None = None
 
     @classmethod
@@ -58,6 +59,7 @@ class BenchmarkRunOptions:
             strategy=spec.get("strategy"),
             step_overrides=spec.get("step_overrides") or [],
             pipeline_attachments=spec.get("pipeline_attachments") or [],
+            experiment_overlays=spec.get("experiment_overlays") or [],
             clean_stale=spec.get("clean_stale"),
         )
 
@@ -131,6 +133,7 @@ async def run_benchmark(
         strategy=opts.strategy,
         step_overrides=opts.step_overrides,
         pipeline_attachments=opts.pipeline_attachments,
+        experiment_overlays=opts.experiment_overlays,
         clean_stale=opts.clean_stale,
     )
 

--- a/lab/components/bench/src/mas/lab/benchmark/execution/experiment_overlay.py
+++ b/lab/components/bench/src/mas/lab/benchmark/execution/experiment_overlay.py
@@ -1,0 +1,164 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Experiment overlay — apply one or more overlay YAMLs to a raw experiment dict.
+
+An experiment overlay is a YAML file that amends an ``experiment.yaml`` without
+modifying it.  It uses the same deep-merge semantics as agent/MAS overlays, with
+one addition: **pipeline hook lists** (``run.post``, ``application.post``, …)
+default to *append* rather than replace, so an overlay can add evaluation
+pipelines without removing the ones declared in the base experiment.
+
+Overlay format
+--------------
+::
+
+    apiVersion: mas/v1
+    kind: ExperimentOverlay
+    metadata:
+      name: my-overlay           # optional
+    spec:
+      # Any key valid inside experiment: {}
+      execution:
+        emulation:
+          runtime:
+            cache: content-addressed
+      run:
+        post:
+          - ref: pipelines/my-eval.yaml   # appended to base run.post list
+      application:
+        post:
+          - ref: pipelines/my-plots.yaml  # appended to base application.post
+
+To *replace* a pipeline list instead of appending, set ``$replace: true``
+at the level block::
+
+    run:
+      $replace: true       # replace run.post/pre entirely
+      post:
+        - ref: pipelines/my-eval.yaml
+
+Precedence (lowest → highest)
+------------------------------
+experiment.yaml  <  overlay files (in order)  <  --infra  <  --flavour  <  --max-runs  <  --set
+
+CLI usage
+---------
+::
+
+    mas-lab benchmark run experiment.yaml \\
+        -x execution/local-dev.yaml \\
+        -x pipelines/standard-eval-overlay.yaml
+
+Multiple ``-x`` flags are applied in order (left to right).
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from mas.ctl.overlay import apply_merge_patch
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_single_overlay(
+    experiment_data: Dict[str, Any],
+    overlay_data: Dict[str, Any],
+    overlay_path: Path,
+) -> Dict[str, Any]:
+    """Apply one overlay dict to the raw experiment dict.
+
+    Uses RFC 7386 JSON Merge Patch semantics via :func:`apply_merge_patch`:
+    dict + dict → recursive merge, everything else (including lists) → replace.
+
+    *experiment_data* is the raw ``{experiment: {...}}`` dict.
+    *overlay_data* is the parsed overlay YAML.
+    """
+    # Normalise to {experiment: {...}} wrapper
+    exp_block = experiment_data.get("experiment", experiment_data)
+
+    # Extract spec from overlay — support both bare dict and {spec: {...}} form
+    overlay_spec: Dict[str, Any]
+    if "spec" in overlay_data:
+        overlay_spec = overlay_data["spec"]
+    elif "experiment" in overlay_data:
+        overlay_spec = overlay_data["experiment"]
+    else:
+        # Bare overlay — treat the whole doc (minus apiVersion/kind/metadata) as spec
+        skip = {"apiVersion", "kind", "metadata"}
+        overlay_spec = {k: v for k, v in overlay_data.items() if k not in skip}
+
+    if not overlay_spec:
+        logger.debug("Experiment overlay %s: empty spec, nothing to merge", overlay_path)
+        return experiment_data
+
+    merged_exp = apply_merge_patch(deepcopy(exp_block), overlay_spec)
+
+    if "experiment" in experiment_data:
+        return {**experiment_data, "experiment": merged_exp}
+    return merged_exp
+
+
+def apply_experiment_overlays(
+    experiment_data: Dict[str, Any],
+    overlay_paths: List[Path],
+    *,
+    base_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Apply a sequence of experiment overlays to *experiment_data*.
+
+    Overlays are applied in order (first overlay applied first).  Each overlay
+    is a deep-merge patch using RFC\u00a07386 JSON Merge Patch semantics:
+    dict\u00a0+\u00a0dict \u2192 recursive merge, everything else (scalars, lists) \u2192 replace.
+    To extend a pipeline list, provide the full desired list in the overlay.
+
+    Parameters
+    ----------
+    experiment_data:
+        Raw parsed experiment YAML dict (``{experiment: {...}}`` or bare).
+    overlay_paths:
+        Paths to overlay YAML files.  Relative paths are resolved from
+        *base_dir* when provided, otherwise from ``cwd``.
+    base_dir:
+        Base directory for relative overlay paths (typically
+        ``experiment_yaml.parent``).
+    """
+    if not overlay_paths:
+        return experiment_data
+
+    try:
+        from mas.runtime.spec.source import load_yaml_file
+    except ImportError:
+        import yaml
+
+        def load_yaml_file(p: Path) -> Dict[str, Any]:  # type: ignore[misc]
+            return yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+
+    result = experiment_data
+    for raw_path in overlay_paths:
+        p = Path(raw_path)
+        if not p.is_absolute() and base_dir is not None:
+            p = (base_dir / p).resolve()
+        if not p.exists():
+            raise FileNotFoundError(
+                f"Experiment overlay not found: {p}"
+            )
+        try:
+            overlay_data = load_yaml_file(p)
+        except Exception as exc:
+            raise ValueError(f"Cannot load experiment overlay {p}: {exc}") from exc
+
+        kind = (overlay_data.get("kind") or "").strip()
+        if kind and kind not in ("ExperimentOverlay", "Experiment"):
+            logger.warning(
+                "Experiment overlay %s has unexpected kind %r (expected ExperimentOverlay)",
+                p, kind,
+            )
+
+        logger.info("Applying experiment overlay: %s", p)
+        result = _apply_single_overlay(result, overlay_data, p)
+
+    return result

--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/__init__.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/__init__.py
@@ -1,9 +1,9 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 """MAS batch scheduler — plan runs, invoke runtime plugins, post-pipeline."""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
@@ -30,6 +30,7 @@ async def run_mas_benchmark(
     strategy: Optional[str] = None,
     step_overrides: Optional[list] = None,
     pipeline_attachments: Optional[list] = None,
+    experiment_overlays: Optional[list] = None,
     clean_stale: Optional[bool] = None,
 ) -> bool:
     """Run a MAS batch benchmark from a *MASExperimentConfig* YAML.
@@ -54,6 +55,7 @@ async def run_mas_benchmark(
         trace_cache_dir=trace_cache_dir,
         step_overrides=step_overrides,
         pipeline_attachments=pipeline_attachments,
+        experiment_overlays=experiment_overlays,
     )
     if loaded is None:
         return False

--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/execute.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/execute.py
@@ -1,11 +1,12 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 """Execute MAS benchmark runs according to the execution plan."""
 
+from __future__ import annotations
+
 import asyncio
+import json as _json
 import logging
 import time as _time
 from dataclasses import dataclass
@@ -51,13 +52,14 @@ async def execute_batch(
 ) -> ExecutionResult:
     """Run all planned (scenario × item × run) executions."""
     import contextlib
+
     from mas.lab.benchmark.service_manager import ServiceManager as _ServiceManager
     from mas.lab.emulation_resolver import resolve_emulation_plugins
 
     exp = loaded.exp
     experiment_yaml = loaded.experiment_yaml
     _flavour = loaded.flavour
-    flavour_name = loaded.flavour_name
+    _flavour_name = loaded.flavour_name
     trace_cache_dir = loaded.trace_cache_dir
     output_dir = prepared.output_dir
 
@@ -94,13 +96,18 @@ async def execute_batch(
     _io_lock  = asyncio.Lock()
 
     _emulation = getattr(exp.execution, "emulation", None)
-    _cache_policy = getattr(getattr(_emulation, "runtime", None), "cache", "content-addressed") if _emulation else "content-addressed"
+    _cache_policy = (
+        getattr(getattr(_emulation, "runtime", None), "cache", "content-addressed")
+        if _emulation
+        else "content-addressed"
+    )
 
     if progress:
         print()
         print(f"Running MAS benchmark '{exp.name}'")
         print(f"  strategy   : {_effective_strategy}")
-        print(f"  {len(prepared.loaded_ids)} scenarios × {len(prepared.dataset_items)} items × {loaded.n_runs} run(s) = {len(_execution_plan)} executions")
+        n_sc, n_items = len(prepared.loaded_ids), len(prepared.dataset_items)
+        print(f"  {n_sc} scenarios × {n_items} items × {loaded.n_runs} run(s) = {len(_execution_plan)} executions")
         print(f"  parallel   : {_parallel}   pause: {_pause}s")
         if _emulation:
             _inf = _emulation.infra
@@ -175,11 +182,35 @@ async def execute_batch(
         _events_path = run_output_dir / "traces" / "events.jsonl"
 
         _use_cache = _cache_policy != "disabled"
+
+        # A global cache hit requires the trace to exist AND the prior run to
+        # have completed successfully.  Absent result.json means the run crashed
+        # before writing its outcome (also a miss).  A run with status=error
+        # may have written a partial events.jsonl — reusing it silently returns
+        # wrong/empty results and corrupts downstream evaluation metrics.
+        _global_result_ok = False
+        _global_result_path = _global_run_dir / "result.json"
+        if _global_result_path.exists():
+            try:
+                _prior = _json.loads(_global_result_path.read_text(encoding="utf-8"))
+                if _prior.get("status") != "error":
+                    _global_result_ok = True
+                else:
+                    logger.debug(
+                        "Cache miss (prior run failed): hash=%s error=%r",
+                        _run_hash[:12], _prior.get("error", "")[:80],
+                    )
+            except Exception:
+                logger.debug(
+                    "Cache miss (result.json unreadable): hash=%s", _run_hash[:12]
+                )
+
         _global_hit = (
             _use_cache
             and not force
             and _cached_events.exists()
             and _cached_events.stat().st_size > 0
+            and _global_result_ok
         )
         _local_hit = (
             _use_cache

--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/load.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/load.py
@@ -1,9 +1,9 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 """Load and validate a MAS experiment for batch execution."""
+
+from __future__ import annotations
 
 import logging
 import sys as _sys
@@ -47,6 +47,7 @@ def load_experiment(
     trace_cache_dir: Optional[Path] = None,
     step_overrides: Optional[list] = None,
     pipeline_attachments: Optional[list] = None,
+    experiment_overlays: Optional[list] = None,
 ) -> LoadedExperiment | None:
     """Load MASExperimentConfig and resolve scenarios, dataset, flavour."""
     try:
@@ -56,13 +57,23 @@ def load_experiment(
         return None
 
     try:
-        from mas.runtime.spec.source import load_yaml_file
         from mas.lab.manifests.validator import (
             ManifestValidationError,
             validate_manifest,
         )
+        from mas.runtime.spec.source import load_yaml_file
 
         raw = load_yaml_file(experiment_yaml)
+
+        if experiment_overlays:
+            from mas.lab.benchmark.execution.experiment_overlay import (
+                apply_experiment_overlays,
+            )
+            raw = apply_experiment_overlays(
+                raw,
+                [Path(p) for p in experiment_overlays],
+                base_dir=experiment_yaml.parent,
+            )
 
         if pipeline_attachments:
             raw = merge_pipeline_attachments(raw, pipeline_attachments)

--- a/lab/components/bench/src/mas/lab/benchmark/worker.py
+++ b/lab/components/bench/src/mas/lab/benchmark/worker.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 """Benchmark execution worker — programmatic API (CLI-free).
 
 This module is the single authoritative entry point for running benchmarks
@@ -33,11 +32,12 @@ Pass ``log_sink`` to capture log lines emitted during the run::
     success = run_benchmark_sync(..., log_sink=lines.append)
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from pathlib import Path
 from typing import Callable, Optional
-
 
 __all__ = [
     "run_benchmark_sync",
@@ -68,6 +68,7 @@ def run_benchmark_sync(
     infra_name: Optional[str] = None,
     step_overrides: Optional[list] = None,
     pipeline_attachments: Optional[list] = None,
+    experiment_overlays: Optional[list] = None,
     log_sink: Optional[Callable[[str], None]] = None,
     clean_stale: Optional[bool] = None,
 ) -> bool:
@@ -136,6 +137,7 @@ def run_benchmark_sync(
             infra_name=infra_name,
             step_overrides=step_overrides or [],
             pipeline_attachments=pipeline_attachments or [],
+            experiment_overlays=experiment_overlays or [],
             clean_stale=clean_stale,
         )
         return asyncio.run(run_benchmark_async(experiment_yaml, options=opts))
@@ -147,7 +149,7 @@ def run_benchmark_sync(
 async def run_benchmark_async(
     experiment_yaml: str | Path,
     *,
-    options: "BenchmarkRunOptions | None" = None,
+    options: "BenchmarkRunOptions | None" = None,  # noqa: F821
 ) -> bool:
     """Async variant — use when already inside an asyncio event loop.
 

--- a/lab/components/bench/tests/test_experiment_overlay.py
+++ b/lab/components/bench/tests/test_experiment_overlay.py
@@ -1,0 +1,173 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Tests for apply_experiment_overlays — experiment YAML deep-merge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from mas.lab.benchmark.execution.experiment_overlay import apply_experiment_overlays
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_overlay(tmp_path: Path, name: str, spec: dict) -> Path:
+    p = tmp_path / name
+    p.write_text(
+        yaml.dump({"apiVersion": "mas/v1", "kind": "ExperimentOverlay", "spec": spec}),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _base() -> dict:
+    return {
+        "experiment": {
+            "name": "my-exp",
+            "execution": {
+                "parallel_scenarios": 2,
+                "emulation": {"runtime": {"cache": "disabled"}},
+            },
+            "run": {"n_runs": 3, "post": [{"ref": "pipelines/a.yaml"}]},
+            "application": {"post": [{"ref": "pipelines/b.yaml"}]},
+            "scenarios": [{"id": "s1"}],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Basic merge
+# ---------------------------------------------------------------------------
+
+def test_no_overlays_returns_unchanged(tmp_path: Path) -> None:
+    base = _base()
+    result = apply_experiment_overlays(base, [], base_dir=tmp_path)
+    assert result == base
+
+
+def test_scalar_override(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "o.yaml", {
+        "execution": {"emulation": {"runtime": {"cache": "content-addressed"}}}
+    })
+    result = apply_experiment_overlays(_base(), [overlay])
+    assert result["experiment"]["execution"]["emulation"]["runtime"]["cache"] == "content-addressed"
+
+
+def test_scalar_override_does_not_affect_unrelated_keys(tmp_path: Path) -> None:
+    spec = {"execution": {"emulation": {"runtime": {"cache": "content-addressed"}}}}
+    overlay = _write_overlay(tmp_path, "o.yaml", spec)
+    result = apply_experiment_overlays(_base(), [overlay])
+    assert result["experiment"]["execution"]["parallel_scenarios"] == 2
+
+
+def test_n_runs_override(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "o.yaml", {"run": {"n_runs": 1}})
+    result = apply_experiment_overlays(_base(), [overlay])
+    assert result["experiment"]["run"]["n_runs"] == 1
+
+
+# ---------------------------------------------------------------------------
+# List replace semantics (RFC 7386)
+# ---------------------------------------------------------------------------
+
+def test_run_post_replaced_by_overlay(tmp_path: Path) -> None:
+    """Lists replace rather than append — provide the full desired list."""
+    overlay = _write_overlay(tmp_path, "o.yaml", {"run": {"post": [{"ref": "pipelines/eval.yaml"}]}})
+    result = apply_experiment_overlays(_base(), [overlay])
+    post = result["experiment"]["run"]["post"]
+    # overlay completely replaces the base list
+    assert post == [{"ref": "pipelines/eval.yaml"}]
+
+
+def test_application_post_replaced_by_overlay(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "o.yaml", {"application": {"post": [{"ref": "pipelines/plots.yaml"}]}})
+    result = apply_experiment_overlays(_base(), [overlay])
+    post = result["experiment"]["application"]["post"]
+    assert post == [{"ref": "pipelines/plots.yaml"}]
+
+
+# ---------------------------------------------------------------------------
+# Multiple overlays applied in order
+# ---------------------------------------------------------------------------
+
+def test_multiple_overlays_applied_left_to_right(tmp_path: Path) -> None:
+    o1 = _write_overlay(tmp_path, "o1.yaml", {"execution": {"parallel_scenarios": 8}})
+    o2 = _write_overlay(tmp_path, "o2.yaml", {"execution": {"parallel_scenarios": 1}})
+    result = apply_experiment_overlays(_base(), [o1, o2])
+    # o2 wins (applied last)
+    assert result["experiment"]["execution"]["parallel_scenarios"] == 1
+
+
+def test_multiple_overlays_pipelines_last_wins(tmp_path: Path) -> None:
+    """Multiple overlays on the same list: last overlay wins (RFC 7386 replace)."""
+    o1 = _write_overlay(tmp_path, "o1.yaml", {"run": {"post": [{"ref": "pipelines/x.yaml"}]}})
+    o2 = _write_overlay(tmp_path, "o2.yaml", {"run": {"post": [{"ref": "pipelines/y.yaml"}]}})
+    result = apply_experiment_overlays(_base(), [o1, o2])
+    refs = [e["ref"] for e in result["experiment"]["run"]["post"]]
+    assert refs == ["pipelines/y.yaml"]  # o2 wins
+
+
+# ---------------------------------------------------------------------------
+# Overlay format variants
+# ---------------------------------------------------------------------------
+
+def test_bare_overlay_without_spec_key(tmp_path: Path) -> None:
+    p = tmp_path / "bare.yaml"
+    p.write_text(yaml.dump({"run": {"n_runs": 7}}), encoding="utf-8")
+    result = apply_experiment_overlays(_base(), [p])
+    assert result["experiment"]["run"]["n_runs"] == 7
+
+
+def test_overlay_with_experiment_key(tmp_path: Path) -> None:
+    p = tmp_path / "exp.yaml"
+    p.write_text(yaml.dump({"experiment": {"run": {"n_runs": 5}}}), encoding="utf-8")
+    result = apply_experiment_overlays(_base(), [p])
+    assert result["experiment"]["run"]["n_runs"] == 5
+
+
+def test_relative_path_resolved_from_base_dir(tmp_path: Path) -> None:
+    _write_overlay(tmp_path, "rel.yaml", {"run": {"n_runs": 2}})
+    result = apply_experiment_overlays(_base(), [Path("rel.yaml")], base_dir=tmp_path)
+    assert result["experiment"]["run"]["n_runs"] == 2
+
+
+def test_missing_overlay_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        apply_experiment_overlays(_base(), [tmp_path / "missing.yaml"])
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_overlay_spec_is_noop(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "empty.yaml", {})
+    base = _base()
+    result = apply_experiment_overlays(base, [overlay])
+    assert result["experiment"] == base["experiment"]
+
+
+def test_overlay_adds_new_level_key(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "o.yaml", {"scenario": {"post": [{"ref": "s.yaml"}]}})
+    result = apply_experiment_overlays(_base(), [overlay])
+    assert result["experiment"]["scenario"]["post"] == [{"ref": "s.yaml"}]
+
+
+def test_original_dict_not_mutated(tmp_path: Path) -> None:
+    overlay = _write_overlay(tmp_path, "o.yaml", {"execution": {"emulation": {"runtime": {"cache": "forced"}}}})
+    base = _base()
+    import copy
+    base_copy = copy.deepcopy(base)
+    apply_experiment_overlays(base, [overlay])
+    assert base == base_copy  # original unchanged
+
+
+def test_bare_experiment_dict_without_experiment_wrapper(tmp_path: Path) -> None:
+    # Some callers pass the inner dict directly without the outer "experiment:" key
+    overlay = _write_overlay(tmp_path, "o.yaml", {"run": {"n_runs": 4}})
+    bare = {"name": "x", "run": {"n_runs": 3}}
+    result = apply_experiment_overlays(bare, [overlay])
+    assert result["run"]["n_runs"] == 4

--- a/lab/docs/design-experiment-overlays.md
+++ b/lab/docs/design-experiment-overlays.md
@@ -1,0 +1,192 @@
+<!--
+  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+  SPDX-License-Identifier: Apache-2.0
+-->
+# Design: Experiment overlays
+
+**Status**: Draft  
+**Branch**: `feat/experiment-overlays`  
+**Relates to**: §5b FT3 (flavour/infra/overlay boundary)
+
+---
+
+## Problem
+
+`experiment.yaml` mixes two distinct concerns:
+
+**Spec** (invariant — *what* to measure):
+```yaml
+scenarios: [baseline, design-pattern, ...]
+dataset: { path: hybrid-regression.yaml }
+design: { mode: coupled, couplings: [...] }
+```
+
+**Execution properties** (operational — *how* to run):
+```yaml
+execution:
+  parallel_scenarios: 2
+  timeout: 600
+  emulation:
+    runtime:
+      cache: disabled    # ← this buried option caused silent re-execution of ALL experiments
+```
+
+The mixing means:
+1. A `cache: disabled` buried deep in the YAML silently bypasses the trace cache,
+   causing every `benchmark run` to make fresh LLM calls — even when debugging a
+   pipeline step.
+2. The CLI has no way to override `emulation.*` properties — it cannot say "use
+   the cache" without editing the YAML.
+3. Different run environments (CI fast-pass, local dev, full benchmark) require
+   separate experiment files or in-place edits, both of which pollute history.
+
+**Principle violated**: CLI should always have the last word.  
+In every other MAS Lab surface (`mas-ctl chat`, `mas-ctl run`, `benchmark run`)
+the CLI overrides YAML.  `emulation.runtime.cache` is the only exception.
+
+---
+
+## Proposed solution: experiment overlays
+
+Parallel to agent/MAS overlays, an **experiment overlay** amends the experiment
+spec at load time without modifying the base YAML.
+
+```
+experiment.yaml          ← the spec (scenarios, dataset, design)
+execution/
+  local-dev.yaml         ← cache=content-addressed, parallel=4, timeout=120
+  ci-fast.yaml           ← n_runs=1, single scenario, mock LLM
+  full-benchmark.yaml    ← n_runs=10, all scenarios, live LLM
+```
+
+CLI composition:
+
+```bash
+# Local dev (fast iteration on pipeline)
+mas-lab benchmark run experiment.yaml -x execution/local-dev.yaml
+
+# CI gate
+mas-lab benchmark run experiment.yaml -x execution/ci-fast.yaml --max-runs 1
+
+# Full benchmark
+mas-lab benchmark run experiment.yaml -x execution/full-benchmark.yaml
+```
+
+The `-x`/`--experiment-overlay` flag (new) applies the overlay before resolving
+any other CLI overrides.  CLI flags (`--max-runs`, `--set`, etc.) still win over
+the overlay.
+
+---
+
+## Overlay schema (draft)
+
+An experiment overlay is a YAML file with the same keys as `experiment:` but
+all fields optional.  Deep merge semantics (same as agent overlays):
+- scalar → replace
+- dict → recursive merge
+- list → replace (explicit `$append`/`$op` for incremental updates)
+
+```yaml
+# execution/local-dev.yaml
+apiVersion: mas/v1
+kind: ExperimentOverlay
+metadata:
+  name: local-dev
+spec:
+  execution:
+    parallel_scenarios: 4
+    timeout: 120
+    emulation:
+      runtime:
+        cache: content-addressed   # never disable in local dev
+  run:
+    n_runs: 1                      # override default 3
+```
+
+```yaml
+# execution/ci-fast.yaml
+apiVersion: mas/v1
+kind: ExperimentOverlay
+metadata:
+  name: ci-fast
+spec:
+  dataset:
+    limit: 1                       # first item only
+  execution:
+    parallel_scenarios: 1
+    emulation:
+      runtime:
+        cache: content-addressed
+  run:
+    n_runs: 1
+```
+
+---
+
+## CLI override chain (precedence, lowest → highest)
+
+```
+experiment.yaml defaults
+  → experiment overlay (-x / --experiment-overlay)
+    → --infra <bundle>
+      → --flavour <name>
+        → --max-runs N
+          → --set KEY=VALUE       (highest, always wins)
+```
+
+This matches the agent/MAS override chain and makes the system predictable.
+
+---
+
+## Alternative: `--set` on experiment keys
+
+A lighter alternative (no new overlay format): extend `--set` to apply to
+experiment-level keys, not just pipeline steps:
+
+```bash
+mas-lab benchmark run experiment.yaml \
+  --set experiment.execution.emulation.runtime.cache=content-addressed \
+  --set experiment.run.n_runs=1
+```
+
+This is lower implementation cost but less ergonomic for multi-key overrides.
+A `--set-experiment KEY=VALUE` flag (separate namespace from `--set`) avoids
+ambiguity with pipeline step names.
+
+---
+
+## Related prior art
+
+- Agent overlays (`overlays/*.yaml`) — same deep-merge pattern
+- `--flavour` — selects deployment posture for the LLM layer
+- `--infra` — selects infrastructure bundle (OTel, storage)
+- `emulation:` block — execution properties that should be overlay-able
+
+The gap: `--flavour` and `--infra` both have CLI flags; `emulation.*` does not.
+
+---
+
+## Implementation sketch
+
+1. `ExperimentOverlay` manifest kind (new, trivial schema)
+2. `load_experiment_with_overlays(yaml_path, overlay_paths)` in `experiment_base.py`
+3. `-x` / `--experiment-overlay` flag on `benchmark run`
+4. Precedence: overlays applied in order, then CLI overrides on top
+5. `--dry-run` prints the merged config (not just the base) so the effective
+   state is auditable
+
+Estimated scope: small (the merge machinery already exists for agent overlays).
+
+---
+
+## Why this matters for reproducibility
+
+An experiment YAML describes the *hypothesis being tested*.  It should be stable
+across environments.  The execution properties (cache, parallelism, LLM mock vs
+live) are *infrastructure concerns* that vary by context.
+
+Mixing them in one file means the experiment YAML changes when the environment
+changes — making git history less meaningful and reproducibility harder.
+
+Separating them (via overlays or `--set`) makes each concern independently
+versionable and auditable.

--- a/lab/src/mas/lab/cli/commands/benchmark/run.py
+++ b/lab/src/mas/lab/cli/commands/benchmark/run.py
@@ -79,6 +79,20 @@ import click
         "Levels: run, test, scenario, application (experiment aliases application)."
     ),
 )
+@click.option(
+    "-x", "--experiment-overlay",
+    "experiment_overlays",
+    multiple=True,
+    metavar="OVERLAY_YAML",
+    help=(
+        "Apply an experiment overlay before running. "
+        "Overlays deep-merge into experiment.yaml; pipeline hook lists (run.post, "
+        "application.post, …) are appended rather than replaced, so overlays can "
+        "add evaluation pipelines without removing base ones. "
+        "Multiple -x flags are applied in order. "
+        "Paths are resolved relative to experiment.yaml's directory."
+    ),
+)
 @click.option("-b", "--background", "background", is_flag=True, default=False,
               help="Submit via controller daemon and return immediately (print worker id).")
 @click.option("--clean-stale", "clean_stale", is_flag=True, default=False,
@@ -91,6 +105,7 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
             data_cache_dir: Path | None,
             force_lock: bool, flavour: str | None, infra: str | None, strategy: str | None,
             step_overrides: tuple[str, ...], pipeline_attachments: tuple[str, ...],
+            experiment_overlays: tuple[str, ...],
             background: bool, clean_stale: bool) -> None:
     """Run a benchmark from an experiment YAML via the controller daemon.
 
@@ -122,6 +137,7 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
                 strategy=strategy,
                 step_overrides=list(step_overrides),
                 pipeline_attachments=list(pipeline_attachments),
+                experiment_overlays=list(experiment_overlays),
                 clean_stale=clean_stale or None,
             )
             raise SystemExit(0 if ok else 1)
@@ -148,6 +164,7 @@ def run_cmd(experiment_yaml: Path, force: bool, resume: bool, benchmark_id: str 
         "strategy": strategy,
         "step_overrides": list(step_overrides),
         "pipeline_attachments": list(pipeline_attachments),
+        "experiment_overlays": list(experiment_overlays),
         "clean_stale": clean_stale,
     }
 

--- a/library-lab/src/mas/library/lab/steps/viz/plotnine.py
+++ b/library-lab/src/mas/library/lab/steps/viz/plotnine.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 """PlotNineStep — render a plotnine (ggplot2-style) chart from a DataFrame.
 
 The ``data`` field accepts a file path (CSV, Parquet, JSON) or an in-memory
@@ -104,6 +103,8 @@ Example YAML — raw tidy CSV with stat_summary::
       depends_on: [collect-metrics]
 """
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Any
@@ -119,17 +120,36 @@ class PlotNineStep(PipelineStep):
 
     type = "plotnine"
 
-    async def execute(self, ctx: "ExecutionContext") -> StepOutput:
+    async def execute(self, ctx: "ExecutionContext") -> StepOutput:  # noqa: F821
+        # Force non-interactive backend before any matplotlib/plotnine import so
+        # the step works from worker threads (benchmark run) as well as the main
+        # thread (benchmark pipeline run).
+        import matplotlib
+        matplotlib.use("Agg")
+
         import numpy as np
         from plotnine import (
-            ggplot, aes,
-            geom_col, geom_bar, geom_point, geom_boxplot, geom_jitter,
-            geom_crossbar, geom_errorbar, geom_errorbarh, geom_line, geom_tile,
-            facet_wrap, facet_grid,
-            labs, theme_minimal, theme, element_text,
+            aes,
+            coord_cartesian,
+            element_text,
+            facet_grid,
+            facet_wrap,
+            geom_bar,
+            geom_boxplot,
+            geom_col,
+            geom_crossbar,
+            geom_errorbar,
+            geom_errorbarh,
+            geom_jitter,
+            geom_line,
+            geom_point,
+            geom_tile,
+            ggplot,
+            labs,
             scale_fill_brewer,
             stat_summary,
-            coord_cartesian,
+            theme,
+            theme_minimal,
         )
 
         config = self.config
@@ -297,7 +317,8 @@ class PlotNineStep(PipelineStep):
             if isinstance(layer_filter, dict):
                 for col, vals in layer_filter.items():
                     if col in layer_df.columns:
-                        layer_df = layer_df[layer_df[col].isin(vals) if isinstance(vals, list) else layer_df[col] == vals]
+                        mask = layer_df[col].isin(vals) if isinstance(vals, list) else layer_df[col] == vals
+                        layer_df = layer_df[mask]
             elif layer_filter:
                 layer_df = layer_df.query(layer_filter)
 
@@ -336,8 +357,15 @@ class PlotNineStep(PipelineStep):
                 point_kwargs.update(layer_geom_kwargs)
                 p = p + geom_point(data=layer_df, mapping=layer_aes, **point_kwargs)
                 # Optional x-out-of-viewport marker for this layer
-                x_col_layer = layer_mapping_cfg.get("x") if isinstance(layer_mapping_cfg, dict) else None
-                if oov_enabled and oov_max is not None and isinstance(x_col_layer, str) and x_col_layer in layer_df.columns:
+                x_col_layer = (
+                    layer_mapping_cfg.get("x") if isinstance(layer_mapping_cfg, dict) else None
+                )
+                if (
+                    oov_enabled
+                    and oov_max is not None
+                    and isinstance(x_col_layer, str)
+                    and x_col_layer in layer_df.columns
+                ):
                     oov_layer_df = layer_df[layer_df[x_col_layer] > float(oov_max)].copy()
                     if not oov_layer_df.empty:
                         oov_layer_df[x_col_layer] = float(oov_max)
@@ -446,7 +474,7 @@ class PlotNineStep(PipelineStep):
             p = p + labs(**labels_cfg)
 
         # ── Theme ──────────────────────────────────────────────────────
-        from plotnine import element_blank, guides
+        from plotnine import element_blank
         p = p + theme_minimal()
         hide_x = config.get("hide_x_labels", False)
         hide_legend = config.get("hide_legend", False)


### PR DESCRIPTION
Adds -x / --experiment-overlay to benchmark run; fixes 3 benchmark bugs
found during development.

New ExperimentOverlay manifest kind: a YAML file that deep-merges into
experiment.yaml before validation, keeping operational concerns out of
the experiment spec.

  mas-lab benchmark run experiment.yaml \
      -x overlays/local-dev.yaml \        # cache + n_runs override
      -x pipelines/standard-eval.yaml      # add reusable eval pipeline

Semantics:
- Precedence: experiment.yaml < overlay(-x) < --infra < --set
- RFC 7386 JSON Merge Patch: dicts merge recursively, everything else
  (scalars, lists) replaces. To extend a pipeline list, provide the
  full desired list in the overlay.
- Paths resolved relative to experiment.yaml directory

Files: execution/experiment_overlay.py, engine.py, run_batch/{__init__,
load}.py, worker.py, cli/commands/benchmark/run.py

- cache: runs with status=error in result.json are no longer treated as
  cache hits; absent or unreadable result.json is also a miss (a run
  that crashed before writing its result must not be reused)
- plotnine: force matplotlib.use('Agg') before import so the step works
  from benchmark worker threads, not only from the main thread
- bootstrap.py: remove stale import of mas.runtime.boundary.context.skills
  deleted in cb8709d; the dead import crashed every agent run

Signed-off-by: Jordan Augé <augjorda@cisco.com>