### PR TITLE
fix: increase max_auto_steps

### DIFF
--- a/runtime/src/mas/runtime/driver/driver.py
+++ b/runtime/src/mas/runtime/driver/driver.py
@@ -97,7 +97,7 @@ class KernelDriver:
     ctx: AutoCtxAssembler | None = field(default_factory=AutoCtxAssembler)
     observability: ObservabilityOperator | None = field(default_factory=ObservabilityOperator)
     coordination: ChokepointCoordinator | None = field(default_factory=ChokepointCoordinator)
-    max_auto_steps: int = 64
+    max_auto_steps: int = 512
     agent_id: str = "agent"
     on_exchange: Callable[[ExchangeRecord], None] | None = None
     capture_engine_io: bool = False
@@ -220,6 +220,19 @@ class KernelDriver:
             if engine_ios:
                 queue.extend(self._dispatch_engine_batch(engine_ios, trace))
 
+        if queue:
+            # auto_steps hit max_auto_steps while items were still queued —
+            # anything left in the queue will be abandoned: exit with error
+            trace.boundary_errors.append(
+                RaiseBoundaryError(
+                    code="STEP_BUDGET_EXHAUSTED",
+                    recoverable=False,
+                    message=(
+                        f"max_auto_steps ({self.max_auto_steps}) exhausted with "
+                        f"{len(queue)} item(s) still queued and undispatched "
+                    ),
+                )
+            )
         trace.awaiting_hitl = gov_is_hitl_pending(self.kernel.q)
         if self.observability is not None:
             trace.observability_events = list(self.observability.events)


### PR DESCRIPTION
mas-ctl run-mas runs could silently truncate mid-turn on multi-agent workflows. Symptoms:

- The run exits with RUN_END status="success" and no exception/traceback.
- The last recorded event is a wm_append of tool_call:<name> for a tool the model requested — immediately followed by turn_commit and the run ending. The tool call is never actually dispatched (no tool_call_start, no governance/contract check, no further LLM call).
- Non-deterministic: only reproduces on some runs, with no consistent trigger.

Root cause

KernelDriver._feed_bounded (runtime/src/mas/runtime/driver/driver.py) bounds a turn's internal processing loop with max_auto_steps (previously set to 64). If auto_steps reaches max_auto_steps before that next pass runs, the while loop simply exits with the item still sitting in the local queue. No exception is raised, nothing is added to trace.rejected_ingress, and the turn is reported as a normal success.

Fix

In runtime/src/mas/runtime/driver/driver.py:

1. max_auto_steps: 64 → 512. 
2. Fail loudly instead of silently. If the step budget is exhausted with items still queued, the driver now appends a RaiseBoundaryError(code="STEP_BUDGET_EXHAUSTED", recoverable=False, ...) to trace.boundary_errors instead of returning a clean-looking trace. 