### PR TITLE
fix(benchmark): allow baseline scenarios with no overlays

### DIFF
--- a/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/prepare.py
+++ b/lab/components/bench/src/mas/lab/benchmark/schedule/run_batch/prepare.py
@@ -110,7 +110,7 @@ def preload_scenario_configs(loaded: LoadedExperiment) -> tuple[dict, dict, list
                     infra_refs=infra_refs,
                 )
                 _scenario_overlay_stacks[_sid] = list(_scenario_spec.overlays.flattened())
-            elif configs_dir is None and exp.mas and exp.mas.manifest:
+            elif (configs_dir is None or (_scenario_spec and not _scenario_spec.overlays.flattened())) and exp.mas and exp.mas.manifest:
                 from mas.lab.manifest.load import load_mas_config
                 _mas_man = load_mas_config(
                     exp.mas.manifest, validate=False, infra_refs=infra_refs

--- a/lab/components/bench/src/mas/lab/lab/config/scenario.py
+++ b/lab/components/bench/src/mas/lab/lab/config/scenario.py
@@ -26,8 +26,6 @@ class OverlayStack:
         logic = list(data.get("logic") or [])
         control = list(data.get("control") or [])
         infra = list(data.get("infra") or [])
-        if not logic and not control and not infra:
-            logic = [scenario_id]
         return cls(logic=logic, control=control, infra=infra)
 
 


### PR DESCRIPTION
## Summary

Fixes a bug where benchmark scenarios declared with empty overlays (`overlays: {}`) were silently skipped, making it impossible to run an app "baseline" scenario with no configuration changes.

**Root causes:**

1. `OverlayStack.from_dict` injected `logic=[scenario_id]` whenever all overlay lists were empty, defeating any explicit attempt to declare a no-overlay scenario. The default should only fire when the `overlays` key is absent entirely — which still happens via `MASScenarioSpec.from_dict`.

2. The base-manifest loading path in `preload_scenario_configs` was gated on `configs_dir is None`, so it was unreachable in experiments mixing overlay and no-overlay scenarios.

**Fix:**
- Remove the fallback injection in `OverlayStack.from_dict`
- Extend the base-manifest path to also trigger when the scenario's flattened overlay list is empty

A baseline scenario can now be declared as:
```yaml
scenarios:
  - id: baseline
    overlays: {}
```