### PR TITLE
perf(lab-registry): eliminate redundant discovery rescans in controller and runtime registry

### DIFF
--- a/lab/components/controller/src/mas/lab/controller/deps.py
+++ b/lab/components/controller/src/mas/lab/controller/deps.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from pathlib import Path
 
 from fastapi import HTTPException
@@ -16,11 +17,25 @@ from mas.lab.controller.constants import HIDDEN_FILES, LIBRARIES_DIR
 logger = logging.getLogger(__name__)
 
 _manifest_store = None
+_manifest_store_last_refresh = 0.0
+
+
+def _refresh_interval_seconds() -> float:
+    """Return manifest refresh throttle interval.
+
+    Set MAS_CONTROLLER_REFRESH_INTERVAL_S=0 to keep legacy refresh-on-every-call behavior.
+    """
+    raw = os.environ.get("MAS_CONTROLLER_REFRESH_INTERVAL_S", "1.0").strip()
+    try:
+        interval = float(raw)
+    except ValueError:
+        return 1.0
+    return max(0.0, interval)
 
 
 def get_manifest_store():
     """Lazy ManifestStore — discovers *.lab dirs and manifest_libraries."""
-    global _manifest_store
+    global _manifest_store, _manifest_store_last_refresh
     if _manifest_store is None:
         from mas.lab.controller.manifest_store import ManifestStore
 
@@ -31,8 +46,13 @@ def get_manifest_store():
         except Exception:
             ws = None
         _manifest_store = ManifestStore(ws)
+        _manifest_store_last_refresh = time.monotonic()
     else:
-        _manifest_store.refresh()
+        now = time.monotonic()
+        interval = _refresh_interval_seconds()
+        if interval <= 0.0 or (now - _manifest_store_last_refresh) >= interval:
+            _manifest_store.refresh()
+            _manifest_store_last_refresh = now
     return _manifest_store
 
 

--- a/lab/components/controller/src/mas/lab/controller/fastapi_app.py
+++ b/lab/components/controller/src/mas/lab/controller/fastapi_app.py
@@ -29,6 +29,7 @@ Job tracking:
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -78,6 +79,13 @@ def _get_library_path(library_name: str):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Emit discovery report once the API process starts."""
+    if os.environ.get("MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        yield
+        return
     try:
         store = get_manifest_store()
         report = store._registry.discovery_report()

--- a/lab/components/controller/src/mas/lab/controller/lab_registry.py
+++ b/lab/components/controller/src/mas/lab/controller/lab_registry.py
@@ -12,6 +12,7 @@ import contextlib
 import importlib.resources
 import logging
 import os
+from functools import lru_cache
 from importlib.metadata import entry_points as _entry_points
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -100,11 +101,57 @@ class LabRegistry:
         self._workspace = workspace
         self._libraries: Dict[str, Path] = {}
         self._library_sources: Dict[str, str] = {}
-        self.refresh()
+        self._refreshed = False
+        # Cache of classified manifest paths keyed by (lib_dir, expected_kind,
+        # parent_dir): populated lazily on first access per library/kind and
+        # reused for the lifetime of the current refresh() cycle. Without this,
+        # every list_experiments()/list_pipelines()/list_datasets()/
+        # list_overlays() call re-walked the entire library tree and re-parsed
+        # every YAML file to reclassify its declared kind, even though the
+        # result is invariant until the next explicit refresh().
+        self._manifest_file_cache: Dict[tuple[Path, str, str | None], List[Path]] = {}
+        eager = os.environ.get("MAS_LAB_REGISTRY_EAGER_REFRESH", "1").strip().lower()
+        if eager not in {"0", "false", "no"}:
+            self.refresh()
+
+    def _ensure_ready(self) -> None:
+        if self._libraries:
+            return
+        if not self._refreshed:
+            self.refresh()
 
     def refresh(self) -> None:
         self._libraries, self._library_sources = self._discover_library_paths()
+        self._manifest_file_cache = {}
         self._log_discovery()
+        self._refreshed = True
+
+    def invalidate_manifest_cache(self) -> None:
+        """Drop cached experiment/pipeline/dataset/overlay file listings.
+
+        The CRUD routes write/delete manifest files directly on the
+        filesystem rather than through this registry, so they must call this
+        after any such write so the next ``list_*`` call rescans instead of
+        returning a listing cached from before the write.
+        """
+        self._manifest_file_cache = {}
+
+    def _cached_manifest_files(
+        self, lib_dir: Path, expected_kind: str, *, parent_dir: str | None = None
+    ) -> List[Path]:
+        """Scan-once wrapper around :func:`_iter_manifest_files`.
+
+        The underlying scan (full ``rglob`` + YAML-parse-and-classify per file)
+        is only ever performed once per (library, kind) pair for the current
+        refresh() cycle; subsequent calls reuse the cached path list.
+        """
+        cache = self._manifest_file_cache
+        key = (lib_dir, expected_kind, parent_dir)
+        cached = cache.get(key)
+        if cached is None:
+            cached = list(_iter_manifest_files(lib_dir, expected_kind, parent_dir=parent_dir))
+            cache[key] = cached
+        return cached
 
     # ── Unified query API (UI / CLI / daemon) ─────────────────────────────
     #
@@ -146,11 +193,19 @@ class LabRegistry:
         raise KeyError(f"LabRegistry.list: unknown spec key {spec_key!r}")
 
     def runtime_objects(self, kind: str) -> Dict[str, Path]:
-        """Objects from ``mas.<kind>s`` entry points (app, dataset, tool)."""
-        try:
-            from mas.registry import list_names, get
+        """Objects from ``mas.<kind>s`` entry points (app, dataset, tool).
 
-            return {name: get(kind, name) for name in list_names(kind)}
+        Uses a single discovery pass (``list_objects``) rather than looping
+        ``get(kind, name)`` per name — each call to ``get``/``list_names``
+        independently re-walks every library root and re-parses every
+        manifest of that kind, so a per-name loop turns an O(1) scan into an
+        O(N) one (this was the actual source of multi-second discovery
+        reports, not the directory walk itself).
+        """
+        try:
+            from mas.registry import list_objects
+
+            return list_objects(kind)
         except ImportError:
             return {}
 
@@ -172,9 +227,11 @@ class LabRegistry:
     # ── Libraries ───────────────────────────────────────────────────────
 
     def library_paths(self) -> Dict[str, Path]:
+        self._ensure_ready()
         return dict(self._libraries)
 
     def libraries(self) -> List[Dict[str, str]]:
+        self._ensure_ready()
         items: List[Dict[str, str]] = []
         for slug, path in sorted(self._libraries.items()):
             items.append(
@@ -187,6 +244,7 @@ class LabRegistry:
         return items
 
     def library_root(self, library: str) -> Path:
+        self._ensure_ready()
         root = self._libraries.get(library)
         if root is None:
             raise KeyError(f"Library {library!r} not found")
@@ -261,6 +319,7 @@ class LabRegistry:
 
     def list_all_experiments(self) -> List[Dict[str, Any]]:
         """All experiment definitions across discovered libraries."""
+        self._ensure_ready()
         items: List[Dict[str, Any]] = []
         for slug in sorted(self._libraries):
             for exp in self.list_experiments(slug):
@@ -269,6 +328,7 @@ class LabRegistry:
 
     def discovery_report(self) -> Dict[str, Any]:
         """Snapshot of paths scanned and libraries resolved (for debugging / UI)."""
+        self._ensure_ready()
         ws_root = self._workspace_root()
         return {
             "workspace_root": str(ws_root) if ws_root else None,
@@ -451,16 +511,16 @@ class LabRegistry:
             )
 
     def _iter_experiment_files(self, lib_dir: Path):
-        yield from _iter_manifest_files(lib_dir, "experiment")
+        yield from self._cached_manifest_files(lib_dir, "experiment")
 
     def _iter_pipeline_files(self, lib_dir: Path):
-        yield from _iter_manifest_files(lib_dir, "pipeline")
+        yield from self._cached_manifest_files(lib_dir, "pipeline")
 
     def _iter_dataset_files(self, lib_dir: Path):
-        yield from _iter_manifest_files(lib_dir, "dataset", parent_dir="datasets")
+        yield from self._cached_manifest_files(lib_dir, "dataset", parent_dir="datasets")
 
     def _iter_overlay_files(self, lib_dir: Path):
-        yield from _iter_manifest_files(lib_dir, "overlay", parent_dir="overlays")
+        yield from self._cached_manifest_files(lib_dir, "overlay", parent_dir="overlays")
 
     def _collect_mas_resources(self, lib_dir: Path) -> Dict[str, Dict[str, Any]]:
         result: Dict[str, Dict[str, Any]] = {}
@@ -563,6 +623,7 @@ class LabRegistry:
         return None
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def discover_bundled_infra() -> Dict[str, str]:
         """Infra bundle YAML from installed ``mas.runtime.manifest_libraries`` packages."""
         bundled: Dict[str, str] = {}

--- a/lab/components/controller/src/mas/lab/controller/manifest_store.py
+++ b/lab/components/controller/src/mas/lab/controller/manifest_store.py
@@ -27,17 +27,39 @@ _SUBDIRS = {
 class ManifestStore:
     """Read/write YAML resources under library roots."""
 
-    def __init__(self, workspace: Any = None) -> None:
+    def __init__(self, workspace: Any = None, *, registry: LabRegistry | None = None) -> None:
+        """Create a store, optionally injecting a specific ``registry``.
+
+        By default the store uses the process-wide :func:`get_lab_registry`
+        singleton. Pass ``registry`` (e.g. a ``LabRegistry`` built with
+        ``MAS_LAB_REGISTRY_EAGER_REFRESH=0`` and manually populated
+        ``_libraries``) to use an isolated registry instead — this is how
+        tests avoid both the global singleton and expensive discovery,
+        without bypassing ``__init__`` via ``__new__``.
+        """
         self._workspace = workspace
-        self._registry = get_lab_registry(workspace)
+        self._registry = registry if registry is not None else get_lab_registry(workspace)
         self._libraries: Dict[str, Path] = {}
-        self.refresh()
+        self._refreshed = False
+
+    def _ensure_ready(self) -> None:
+        # Many tests override _libraries directly; avoid expensive discovery if already injected.
+        if self._libraries:
+            return
+        if not self._refreshed:
+            self.refresh()
 
     def refresh(self) -> None:
         self._registry.refresh()
         self._libraries = self._registry.library_paths()
+        self._refreshed = True
+
+    def invalidate(self) -> None:
+        """Drop cached manifest-file listings (see LabRegistry.invalidate_manifest_cache)."""
+        self._registry.invalidate_manifest_cache()
 
     def libraries(self) -> List[Dict[str, str]]:
+        self._ensure_ready()
         items: List[Dict[str, str]] = []
         for slug, path in sorted(self._libraries.items()):
             items.append(
@@ -50,6 +72,7 @@ class ManifestStore:
         return items
 
     def library_root(self, library: str) -> Path:
+        self._ensure_ready()
         root = self._libraries.get(library)
         if root is not None:
             return root
@@ -138,11 +161,11 @@ class ManifestStore:
         flavours: Dict[str, str] = {}
         infra: Dict[str, str] = {}
 
-        for path in sorted(root.rglob("flavours/*.yaml")) + sorted(root.rglob("flavours/*.yml")):
+        for path in sorted(p for p in root.rglob("flavours/*") if p.suffix in (".yaml", ".yml")):
             if path.is_file():
                 flavours[str(path.relative_to(root))] = path.read_text(encoding="utf-8")
 
-        for path in sorted(root.rglob("infra/*.yaml")) + sorted(root.rglob("infra/*.yml")):
+        for path in sorted(p for p in root.rglob("infra/*") if p.suffix in (".yaml", ".yml")):
             if path.is_file():
                 infra[str(path.relative_to(root))] = path.read_text(encoding="utf-8")
 

--- a/lab/components/controller/src/mas/lab/controller/routes/datasets.py
+++ b/lab/components/controller/src/mas/lab/controller/routes/datasets.py
@@ -34,6 +34,7 @@ def create_dataset(library_name: str, req: SaveDatasetRequest):
         raise HTTPException(status_code=409, detail=f"Dataset '{filename}' already exists")
 
     file_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": filename}
 
 
@@ -71,6 +72,7 @@ def update_dataset(library_name: str, dataset_name: str, req: SaveDatasetRequest
     if old_path != new_path:
         old_path.unlink()
     new_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": new_name}
 
 
@@ -85,4 +87,5 @@ def delete_dataset(library_name: str, dataset_name: str):
         raise HTTPException(status_code=404, detail=f"Dataset '{dataset_name}' not found")
 
     file_path.unlink()
+    deps.get_manifest_store().invalidate()
     return {"deleted": dataset_name}

--- a/lab/components/controller/src/mas/lab/controller/routes/experiments.py
+++ b/lab/components/controller/src/mas/lab/controller/routes/experiments.py
@@ -35,6 +35,7 @@ async def create_experiment(library_name: str, req: SaveExperimentRequest):
         raise HTTPException(status_code=409, detail=f"Experiment '{req.name}' already exists")
 
     file_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": filename}
 
 
@@ -85,6 +86,7 @@ async def update_experiment(library_name: str, experiment_name: str, req: SaveEx
     if old_path != new_path:
         old_path.unlink()
     new_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": new_filename}
 
 
@@ -99,4 +101,5 @@ async def delete_library_experiment(library_name: str, experiment_name: str):
         raise HTTPException(status_code=404, detail=f"Experiment '{experiment_name}' not found")
 
     file_path.unlink()
+    deps.get_manifest_store().invalidate()
     return {"deleted": experiment_name}

--- a/lab/components/controller/src/mas/lab/controller/routes/overlays.py
+++ b/lab/components/controller/src/mas/lab/controller/routes/overlays.py
@@ -95,6 +95,7 @@ async def create_overlay(library_name: str, req: SaveOverlayRequest):
             raise HTTPException(status_code=422, detail=result)
 
     file_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": filename}
 
 
@@ -137,6 +138,7 @@ async def update_overlay(library_name: str, overlay_name: str, req: SaveOverlayR
     if old_path != new_path:
         old_path.unlink()
     new_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": new_filename}
 
 
@@ -150,4 +152,5 @@ async def delete_overlay(library_name: str, overlay_name: str):
         raise HTTPException(status_code=404, detail=f"Overlay '{overlay_name}' not found")
 
     file_path.unlink()
+    deps.get_manifest_store().invalidate()
     return {"deleted": overlay_name}

--- a/lab/components/controller/src/mas/lab/controller/routes/pipelines.py
+++ b/lab/components/controller/src/mas/lab/controller/routes/pipelines.py
@@ -77,6 +77,7 @@ async def create_pipeline(library_name: str, req: SavePipelineRequest):
             raise HTTPException(status_code=422, detail=result["errors"])
 
     file_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": filename}
 
 
@@ -119,6 +120,7 @@ async def update_pipeline(library_name: str, pipeline_name: str, req: SavePipeli
     if old_path != new_path:
         old_path.unlink()
     new_path.write_text(req.content, encoding="utf-8")
+    deps.get_manifest_store().invalidate()
     return {"name": req.name, "filename": new_filename}
 
 
@@ -133,4 +135,5 @@ async def delete_pipeline(library_name: str, pipeline_name: str):
         raise HTTPException(status_code=404, detail=f"Pipeline '{pipeline_name}' not found")
 
     file_path.unlink()
+    deps.get_manifest_store().invalidate()
     return {"deleted": pipeline_name}

--- a/lab/components/controller/tests/conftest.py
+++ b/lab/components/controller/tests/conftest.py
@@ -10,6 +10,14 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _controller_test_defaults(monkeypatch: pytest.MonkeyPatch):
+    """Speed up controller tests by disabling startup discovery noise and churn."""
+    monkeypatch.setenv("MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY", "1")
+    monkeypatch.setenv("MAS_CONTROLLER_REFRESH_INTERVAL_S", "5")
+    monkeypatch.setenv("MAS_LAB_REGISTRY_EAGER_REFRESH", "0")
+
+
 @pytest.fixture
 def temp_mas_home(monkeypatch: pytest.MonkeyPatch):
     with tempfile.TemporaryDirectory() as tmp:

--- a/lab/components/controller/tests/test_api_calls_contract.py
+++ b/lab/components/controller/tests/test_api_calls_contract.py
@@ -314,6 +314,86 @@ def test_contract_scenarios_and_datasets(client):
         assert "path" in d
 
 
+# --- Datasets CRUD (apiCalls: create/update/delete dataset) ---
+
+
+def test_contract_datasets_crud(client, demo_lab):
+    dataset_yaml = (
+        "apiVersion: lab/v1\nkind: Dataset\nmetadata:\n  name: new-dataset\n"
+        "spec:\n  items: []\n"
+    )
+    created = client.post(
+        "/api/libraries/demo/datasets",
+        json={"name": "new-dataset", "content": dataset_yaml},
+    )
+    assert created.status_code == 201
+    assert (demo_lab / "datasets" / "new-dataset.yaml").exists()
+
+    after_create = client.get("/api/libraries/demo/datasets").json()
+    assert "new-dataset.yaml" in {d["name"] for d in after_create["datasets"]}
+
+    renamed_yaml = dataset_yaml.replace("name: new-dataset", "name: renamed-dataset")
+    updated = client.put(
+        "/api/libraries/demo/datasets/new-dataset",
+        json={"name": "renamed-dataset", "content": renamed_yaml},
+    )
+    assert updated.status_code == 200
+    assert not (demo_lab / "datasets" / "new-dataset.yaml").exists()
+    assert (demo_lab / "datasets" / "renamed-dataset.yaml").exists()
+
+    after_rename = client.get("/api/libraries/demo/datasets").json()
+    after_rename_names = {d["name"] for d in after_rename["datasets"]}
+    assert "renamed-dataset.yaml" in after_rename_names
+    assert "new-dataset.yaml" not in after_rename_names
+
+    deleted = client.delete("/api/libraries/demo/datasets/renamed-dataset")
+    assert deleted.status_code in (200, 204)
+    assert not (demo_lab / "datasets" / "renamed-dataset.yaml").exists()
+
+    after_delete = client.get("/api/libraries/demo/datasets").json()
+    assert "renamed-dataset.yaml" not in {d["name"] for d in after_delete["datasets"]}
+
+
+# --- Overlays CRUD (apiCalls: create/update/delete overlay) ---
+
+
+def test_contract_overlays_crud(client, demo_lab):
+    overlay_yaml = (
+        "apiVersion: mas/v1\nkind: Overlay\nmetadata:\n  name: new-overlay\n"
+        "  namespace: global\n  description: new overlay\n"
+    )
+    created = client.post(
+        "/api/libraries/demo/overlays",
+        json={"name": "new-overlay", "content": overlay_yaml, "run_validation": False},
+    )
+    assert created.status_code == 201
+    assert (demo_lab / "overlays" / "new-overlay.yaml").exists()
+
+    after_create = client.get("/api/libraries/demo/overlays").json()
+    assert "new-overlay" in {o["name"] for o in after_create["overlays"]}
+
+    renamed_yaml = overlay_yaml.replace("name: new-overlay", "name: renamed-overlay")
+    updated = client.put(
+        "/api/libraries/demo/overlays/new-overlay",
+        json={"name": "renamed-overlay", "content": renamed_yaml, "run_validation": False},
+    )
+    assert updated.status_code == 200
+    assert not (demo_lab / "overlays" / "new-overlay.yaml").exists()
+    assert (demo_lab / "overlays" / "renamed-overlay.yaml").exists()
+
+    after_rename = client.get("/api/libraries/demo/overlays").json()
+    after_rename_names = {o["name"] for o in after_rename["overlays"]}
+    assert "renamed-overlay" in after_rename_names
+    assert "new-overlay" not in after_rename_names
+
+    deleted = client.delete("/api/libraries/demo/overlays/renamed-overlay")
+    assert deleted.status_code in (200, 204)
+    assert not (demo_lab / "overlays" / "renamed-overlay.yaml").exists()
+
+    after_delete = client.get("/api/libraries/demo/overlays").json()
+    assert "renamed-overlay" not in {o["name"] for o in after_delete["overlays"]}
+
+
 # --- Experiments CRUD (apiCalls: fetch/create/update/delete experiment) ---
 
 
@@ -336,6 +416,11 @@ def test_contract_experiments_crud(client, demo_lab):
     assert created.status_code == 201
     assert (demo_lab / "experiments" / "new-experiment.yaml").exists()
 
+    # Regression guard: the manifest-file cache must be invalidated on write,
+    # otherwise this list would still be the one scanned before the create.
+    after_create = client.get("/api/libraries/demo/experiments").json()
+    assert "new-experiment" in {e["name"] for e in after_create["experiments"]}
+
     readback = client.get("/api/libraries/demo/experiments/new-experiment").json()
     assert "content" in readback
     import yaml as _yaml
@@ -355,9 +440,17 @@ def test_contract_experiments_crud(client, demo_lab):
     assert not (demo_lab / "experiments" / "new-experiment.yaml").exists()
     assert (demo_lab / "experiments" / "renamed-experiment.yaml").exists()
 
+    after_rename = client.get("/api/libraries/demo/experiments").json()
+    after_rename_names = {e["name"] for e in after_rename["experiments"]}
+    assert "renamed-experiment" in after_rename_names
+    assert "new-experiment" not in after_rename_names
+
     deleted = client.delete("/api/libraries/demo/experiments/renamed-experiment")
     assert deleted.status_code in (200, 204)
     assert not (demo_lab / "experiments" / "renamed-experiment.yaml").exists()
+
+    after_delete = client.get("/api/libraries/demo/experiments").json()
+    assert "renamed-experiment" not in {e["name"] for e in after_delete["experiments"]}
 
 
 # --- Experiment cache / detail (apiCalls: deleteExperimentCache, fetchExperimentDetail) ---
@@ -425,6 +518,9 @@ def test_contract_pipelines(mock_submit_job, client, demo_lab):
     assert created.status_code == 201
     assert (demo_lab / "pipelines" / "analysis-pipeline.yaml").exists()
 
+    after_create = client.get("/api/libraries/demo/pipelines").json()
+    assert "analysis-pipeline" in {p["name"] for p in after_create["pipelines"]}
+
     renamed_yaml = pipeline_yaml.replace(
         "name: analysis-pipeline", "name: renamed-pipeline"
     )
@@ -436,6 +532,11 @@ def test_contract_pipelines(mock_submit_job, client, demo_lab):
     assert not (demo_lab / "pipelines" / "analysis-pipeline.yaml").exists()
     assert (demo_lab / "pipelines" / "renamed-pipeline.yaml").exists()
 
+    after_rename = client.get("/api/libraries/demo/pipelines").json()
+    after_rename_names = {p["name"] for p in after_rename["pipelines"]}
+    assert "renamed-pipeline" in after_rename_names
+    assert "analysis-pipeline" not in after_rename_names
+
     run = client.post(
         "/api/libraries/demo/pipeline/run",
         json={"pipeline_yaml": renamed_yaml},
@@ -443,9 +544,20 @@ def test_contract_pipelines(mock_submit_job, client, demo_lab):
     assert run.status_code == 202
     assert "job_id" in run.json()
 
+    # /pipeline/run writes an inline-content temp file (pipeline-*.yaml) directly
+    # under the library root; mock_submit_job doesn't run the real cleanup, so
+    # remove it here to isolate the delete-reflects-in-list assertion below
+    # from this unrelated temp-file artifact (unrestricted pipeline discovery
+    # scans the whole library tree, not just pipelines/).
+    for tmp_file in demo_lab.glob("pipeline-*.yaml"):
+        tmp_file.unlink()
+
     deleted = client.delete("/api/libraries/demo/pipelines/renamed-pipeline")
     assert deleted.status_code in (200, 204)
     assert not (demo_lab / "pipelines" / "renamed-pipeline.yaml").exists()
+
+    after_delete = client.get("/api/libraries/demo/pipelines").json()
+    assert "renamed-pipeline" not in {p["name"] for p in after_delete["pipelines"]}
 
 
 # --- Overlays CRUD + validate (apiCalls) ---

--- a/lab/components/controller/tests/test_client.py
+++ b/lab/components/controller/tests/test_client.py
@@ -191,6 +191,7 @@ def test_ensure_running_failure(temp_mas_home, monkeypatch):
 
     monkeypatch.setattr(client_mod, "start_daemon", lambda **kw: None)
     monkeypatch.setattr(client_mod.ControllerClient, "is_running", lambda self: False)
+    monkeypatch.setattr(client_mod.time, "sleep", lambda _s: None)
     client = ControllerClient()
     with pytest.raises(RuntimeError, match="failed to start"):
         client.ensure_running(auto_start=True)

--- a/lab/components/controller/tests/test_controller.py
+++ b/lab/components/controller/tests/test_controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -54,3 +55,41 @@ def test_controller_api_submit_benchmark_worker():
         assert api.get_worker(result["worker_id"]) is not None
     finally:
         Path(exp_path).unlink(missing_ok=True)
+
+
+def test_get_manifest_store_refresh_throttled(monkeypatch):
+    import mas.lab.controller.deps as deps
+
+    fake_store = SimpleNamespace(refresh=lambda: None)
+    calls = {"n": 0}
+
+    def _refresh():
+        calls["n"] += 1
+
+    fake_store.refresh = _refresh
+
+    monkeypatch.setattr(deps, "_manifest_store", fake_store)
+    monkeypatch.setattr(deps, "_manifest_store_last_refresh", 100.0)
+    monkeypatch.setattr(deps.time, "monotonic", lambda: 100.2)
+    monkeypatch.setenv("MAS_CONTROLLER_REFRESH_INTERVAL_S", "1.0")
+
+    deps.get_manifest_store()
+    assert calls["n"] == 0
+
+
+def test_get_manifest_store_refresh_forced_with_zero_interval(monkeypatch):
+    import mas.lab.controller.deps as deps
+
+    calls = {"n": 0}
+
+    def _refresh():
+        calls["n"] += 1
+
+    fake_store = SimpleNamespace(refresh=_refresh)
+    monkeypatch.setattr(deps, "_manifest_store", fake_store)
+    monkeypatch.setattr(deps, "_manifest_store_last_refresh", 100.0)
+    monkeypatch.setattr(deps.time, "monotonic", lambda: 100.1)
+    monkeypatch.setenv("MAS_CONTROLLER_REFRESH_INTERVAL_S", "0")
+
+    deps.get_manifest_store()
+    assert calls["n"] == 1

--- a/lab/components/controller/tests/test_fastapi_app.py
+++ b/lab/components/controller/tests/test_fastapi_app.py
@@ -19,9 +19,16 @@ _TEMPLATES = Path(__file__).resolve().parent / "fixtures" / "templates"
 
 
 def _fake_store(lab: Path):
+    from mas.lab.controller.lab_registry import LabRegistry
     from mas.lab.controller.manifest_store import ManifestStore
 
-    store = ManifestStore(workspace=None)
+    # Normal construction: the autouse `_controller_test_defaults` fixture sets
+    # MAS_LAB_REGISTRY_EAGER_REFRESH=0, so LabRegistry() does no discovery here.
+    # Only one in-memory demo library is needed, injected after construction.
+    registry = LabRegistry(workspace=None)
+    registry._libraries = {"demo": lab}
+    registry._library_sources = {"demo": "test-fixture"}
+    store = ManifestStore(registry=registry)
     store._libraries = {"demo": lab}
     return store
 
@@ -38,9 +45,11 @@ def demo_lab(tmp_path: Path) -> Path:
 def client(demo_lab, monkeypatch):
     from mas.lab.controller import fastapi_app
 
+    store = _fake_store(demo_lab)
+
     monkeypatch.setattr(
         "mas.lab.controller.deps.get_manifest_store",
-        lambda: _fake_store(demo_lab),
+        lambda: store,
     )
     return TestClient(fastapi_app.app)
 
@@ -92,14 +101,29 @@ def test_experiments_crud(client, demo_lab):
     assert resp.status_code == 201
     assert (demo_lab / "experiments" / "newone.yaml").exists()
 
+    # Regression guard: the list endpoint must reflect the write immediately,
+    # not a listing cached from before the create (invalidate() on write).
+    # `filename` (unlike `name`, which is parsed from the YAML content and may
+    # differ from the on-disk name) is a reliable proxy for the written file.
+    after_create = client.get("/api/libraries/demo/experiments").json()["experiments"]
+    assert any(e["filename"] == "newone.yaml" for e in after_create)
+
     client.put(
         "/api/libraries/demo/experiments/newone",
-        json={"name": "renamed", "content": "metadata:\n  name: renamed\n"},
+        json={"name": "renamed", "content": newone_yaml.replace("name: new-experiment", "name: renamed")},
     )
     assert (demo_lab / "experiments" / "renamed.yaml").exists()
 
+    after_rename = client.get("/api/libraries/demo/experiments").json()["experiments"]
+    after_rename_filenames = {e["filename"] for e in after_rename}
+    assert "renamed.yaml" in after_rename_filenames
+    assert "newone.yaml" not in after_rename_filenames
+
     client.delete("/api/libraries/demo/experiments/renamed")
     assert not (demo_lab / "experiments" / "renamed.yaml").exists()
+
+    after_delete = client.get("/api/libraries/demo/experiments").json()["experiments"]
+    assert "renamed.yaml" not in {e["filename"] for e in after_delete}
 
 
 # -- Pipelines & Overlays ----------------------------------------------------

--- a/lab/components/controller/tests/test_fastapi_extended.py
+++ b/lab/components/controller/tests/test_fastapi_extended.py
@@ -199,6 +199,48 @@ async def test_run_job_paths(monkeypatch, tmp_path):
     assert job2.status == jobs.JobStatus.FAILED
 
 
+@pytest.mark.asyncio
+async def test_lifespan_disabled_skips_discovery(monkeypatch):
+    """MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY must short-circuit before
+    touching the manifest store at all."""
+    from mas.lab.controller import fastapi_app
+
+    monkeypatch.setenv("MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY", "1")
+
+    def _boom():
+        raise AssertionError("get_manifest_store() must not be called when startup discovery is disabled")
+
+    monkeypatch.setattr(fastapi_app, "get_manifest_store", _boom)
+
+    async with fastapi_app.lifespan(fastapi_app.app):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_enabled_emits_discovery_report(monkeypatch):
+    """Default behavior (flag unset/false): lifespan fetches the manifest
+    store and logs a single discovery report on startup."""
+    from mas.lab.controller import fastapi_app
+
+    monkeypatch.setenv("MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY", "0")
+    calls = {"n": 0}
+
+    class _FakeRegistry:
+        def discovery_report(self):
+            calls["n"] += 1
+            return {"libraries": []}
+
+    class _FakeStore:
+        _registry = _FakeRegistry()
+
+    monkeypatch.setattr(fastapi_app, "get_manifest_store", lambda: _FakeStore())
+
+    async with fastapi_app.lifespan(fastapi_app.app):
+        pass
+
+    assert calls["n"] == 1
+
+
 def test_api_info_and_topologies(client, demo_lab):
     info = client.get("/api/info").json()
     assert "libraries_dir" in info

--- a/lab/components/controller/tests/test_lab_discovery.py
+++ b/lab/components/controller/tests/test_lab_discovery.py
@@ -145,7 +145,7 @@ def test_lab_library_includes_workspace_apps(nested_lab: Path, monkeypatch):
     reset_lab_registry()
 
 
-def test_config_files_include_workspace_infra(tmp_path: Path):
+def test_config_files_include_workspace_infra(tmp_path: Path, monkeypatch):
     ws = tmp_path / "workspace"
     ws.mkdir()
     (ws / "infra").mkdir()
@@ -156,20 +156,26 @@ def test_config_files_include_workspace_infra(tmp_path: Path):
     lab = ws / "labs" / "demo.lab"
     lab.mkdir(parents=True)
 
-    reset_lab_registry()
-    reg = LabRegistry()
-    reg._libraries = {"demo": lab}
-    monkeypatch_ws = type("Ws", (), {"_path": ws, "_data": {}})()
-    reg._workspace = monkeypatch_ws
+    monkeypatch.setattr(
+        "mas.lab.controller.lab_registry.LabRegistry.discover_bundled_infra",
+        classmethod(lambda cls: {}),
+    )
 
     from mas.lab.controller.manifest_store import ManifestStore
 
-    store = ManifestStore(monkeypatch_ws)
+    monkeypatch_ws = type("Ws", (), {"_path": ws, "_data": {}})()
+    # Normal construction: the autouse `_controller_test_defaults` fixture sets
+    # MAS_LAB_REGISTRY_EAGER_REFRESH=0, so LabRegistry() does no discovery here.
+    registry = LabRegistry(workspace=monkeypatch_ws)
+    registry._libraries = {"demo": lab}
+    registry._library_sources = {"demo": "test-fixture"}
+    store = ManifestStore(workspace=monkeypatch_ws, registry=registry)
     store._libraries = {"demo": lab}
     configs = store.config_files("demo")
     assert any(k.startswith("workspace/infra/") for k in configs["infra"])
     assert "config.yaml" not in configs["workspace"] or configs["workspace"] == {}
     reset_lab_registry()
+
 
 
 def test_list_all_experiments_across_libraries(tmp_path: Path):
@@ -188,6 +194,95 @@ def test_list_all_experiments_across_libraries(tmp_path: Path):
     all_exps = reg.list_all_experiments()
     assert len(all_exps) == 2
     assert {e["library"] for e in all_exps} == {"a", "b"}
+    reset_lab_registry()
+
+
+def test_manifest_file_cache_reused_until_refresh(nested_lab: Path, monkeypatch):
+    """_iter_manifest_files is only invoked once per (library, kind); repeated
+    list_*() calls must reuse the cached path list until refresh() runs."""
+    import mas.lab.controller.lab_registry as lab_registry_mod
+
+    reset_lab_registry()
+    reg = LabRegistry()
+    reg._libraries = {"design-space": nested_lab}
+
+    calls = {"n": 0}
+    real_iter = lab_registry_mod._iter_manifest_files
+
+    def counting_iter(*args, **kwargs):
+        calls["n"] += 1
+        return real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(lab_registry_mod, "_iter_manifest_files", counting_iter)
+
+    reg.list_experiments("design-space")
+    reg.list_experiments("design-space")
+    assert calls["n"] == 1, "second call should reuse the cached path list"
+
+    reg.refresh()
+    reg._libraries = {"design-space": nested_lab}
+    reg.list_experiments("design-space")
+    assert calls["n"] == 2, "refresh() must force a rescan"
+
+    reset_lab_registry()
+
+
+def test_invalidate_manifest_cache_forces_rescan(nested_lab: Path, monkeypatch):
+    """CRUD routes write manifest files directly to disk, bypassing the
+    registry, so invalidate_manifest_cache() must force the next list_*()
+    call to rescan instead of returning a listing cached from before the
+    write."""
+    import mas.lab.controller.lab_registry as lab_registry_mod
+
+    reset_lab_registry()
+    reg = LabRegistry()
+    reg._libraries = {"design-space": nested_lab}
+
+    calls = {"n": 0}
+    real_iter = lab_registry_mod._iter_manifest_files
+
+    def counting_iter(*args, **kwargs):
+        calls["n"] += 1
+        return real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(lab_registry_mod, "_iter_manifest_files", counting_iter)
+
+    reg.list_experiments("design-space")
+    assert calls["n"] == 1
+
+    reg.invalidate_manifest_cache()
+    reg.list_experiments("design-space")
+    assert calls["n"] == 2, "invalidate_manifest_cache() must force a rescan"
+
+    reset_lab_registry()
+
+
+def test_manifest_store_invalidate_delegates_to_registry(nested_lab: Path, monkeypatch):
+    reset_lab_registry()
+    registry = LabRegistry()
+    registry._libraries = {"design-space": nested_lab}
+
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        registry, "invalidate_manifest_cache", lambda: calls.__setitem__("n", calls["n"] + 1)
+    )
+
+    store = ManifestStore(registry=registry)
+    store._libraries = {"design-space": nested_lab}
+    store.invalidate()
+    assert calls["n"] == 1
+    reset_lab_registry()
+
+
+def test_manifest_store_registry_injection_bypasses_singleton():
+    """ManifestStore(registry=...) must use the injected registry instead of
+    the process-wide get_lab_registry() singleton."""
+    reset_lab_registry()
+    registry = LabRegistry()
+    registry._libraries = {"demo": Path("/nonexistent")}
+
+    store = ManifestStore(registry=registry)
+    assert store._registry is registry
     reset_lab_registry()
 
 

--- a/lab/components/controller/tests/test_lab_registry.py
+++ b/lab/components/controller/tests/test_lab_registry.py
@@ -59,6 +59,29 @@ def test_default_model_is_gpt4o_mini():
     reset_lab_registry()
 
 
+def test_runtime_objects_delegates_to_list_objects_single_pass(monkeypatch):
+    """runtime_objects() must call mas.registry.list_objects() exactly once,
+    not loop get()/list_names() per name (the source of the N+1 rescan bug)."""
+    import mas.registry as registry_mod
+
+    reset_lab_registry()
+    reg = get_lab_registry()
+
+    calls = {"n": 0}
+    real_list_objects = registry_mod.list_objects
+
+    def counting_list_objects(kind: str):
+        calls["n"] += 1
+        return real_list_objects(kind)
+
+    monkeypatch.setattr(registry_mod, "list_objects", counting_list_objects)
+
+    objects = reg.runtime_objects("dataset")
+    assert calls["n"] == 1
+    assert objects == real_list_objects("dataset")
+    reset_lab_registry()
+
+
 def test_list_experiments_lab_layout(tmp_path: Path):
     lab = tmp_path / "demo.lab"
     lab.mkdir()

--- a/lab/components/controller/tests/test_manifest_store.py
+++ b/lab/components/controller/tests/test_manifest_store.py
@@ -69,6 +69,24 @@ def test_library_description_readme(sample_lab):
     assert libs[0]["description"].startswith("# Demo")
 
 
+def test_config_files_picks_up_both_yaml_and_yml_suffixes(sample_lab):
+    """config_files() consolidates 4 rglob scans into 2 suffix-filtered ones —
+    both .yaml and .yml must still be discovered in flavours/ and infra/."""
+    (sample_lab / "flavours" / "local.yml").write_text(
+        "metadata:\n  name: local-short-suffix\n", encoding="utf-8"
+    )
+    (sample_lab / "infra" / "proxy.yml").write_text(
+        "kind: LLMProxy\nmetadata:\n  name: proxy-short-suffix\n", encoding="utf-8"
+    )
+    store = ManifestStore(workspace=None)
+    store._libraries = {"demo": sample_lab}
+
+    configs = store.config_files("demo")
+    assert any(k.endswith("local.yml") for k in configs["flavours"])
+    assert any(k.endswith("proxy.yml") for k in configs["infra"])
+    assert any(k.endswith("tools.yaml") for k in configs["infra"])
+
+
 def test_discover_from_workspace(tmp_path):
     from mas.lab.controller.lab_registry import LabRegistry, reset_lab_registry
 

--- a/runtime/src/mas/registry.py
+++ b/runtime/src/mas/registry.py
@@ -58,6 +58,18 @@ def list_names(kind: str) -> list[str]:
     return sorted(_discover(kind))
 
 
+def list_objects(kind: str) -> dict[str, Path]:
+    """Return the full ``{name: path}`` mapping for *kind* in a single discovery pass.
+
+    Prefer this over calling :func:`get` once per name from :func:`list_names`
+    — each call to :func:`get`/:func:`list_names` independently re-walks the
+    filesystem and re-parses every manifest of that kind (no caching, since
+    library roots/env can change between calls), so building a full mapping
+    via a per-name ``get()`` loop is O(N) full rescans instead of one.
+    """
+    return dict(_discover(kind))
+
+
 def resolve_locator(
     locator: Union[str, dict],
     kind: str,

--- a/runtime/tests/test_library_catalog.py
+++ b/runtime/tests/test_library_catalog.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from mas.apps import get_app, list_apps
-from mas.registry import get, list_names
+from mas.registry import get, list_names, list_objects
 
 
 def test_discover_sample_apps() -> None:
@@ -23,3 +23,30 @@ def test_discover_sample_datasets() -> None:
     path = get("dataset", "trip-planner-benchmark")
     assert path.name == "benchmark.yaml"
     assert "trip-planner" in str(path)
+
+
+def test_list_objects_matches_list_names_and_get() -> None:
+    """list_objects() must agree with the per-name get()/list_names() API."""
+    objects = list_objects("dataset")
+    names = list_names("dataset")
+    assert set(objects) == set(names)
+    for name in names:
+        assert objects[name] == get("dataset", name)
+
+
+def test_list_objects_performs_a_single_discovery_pass(monkeypatch) -> None:
+    """Regression guard for the N+1 rescan bug: list_objects() must call
+    _discover() exactly once, not once per object (as a get() loop would)."""
+    import mas.registry as registry_mod
+
+    calls = {"n": 0}
+    real_discover = registry_mod._discover
+
+    def counting_discover(kind: str):
+        calls["n"] += 1
+        return real_discover(kind)
+
+    monkeypatch.setattr(registry_mod, "_discover", counting_discover)
+    objects = registry_mod.list_objects("dataset")
+    assert len(objects) > 1, "fixture must expose more than one dataset for this guard to be meaningful"
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary

- `mas.registry.list_objects(kind)` performs a single `_discover()` pass instead of looping `get()`/`list_names()` per object name (eliminates an O(N+1) rescan in runtime object listings).
- `LabRegistry` caches manifest file lists per `(library, kind)` and only rescans on `refresh()`/`invalidate_manifest_cache()`; CRUD routes call `ManifestStore.invalidate()` after every write so the next list reflects the change immediately.
- `ManifestStore` accepts an injected `registry` (constructor param) instead of relying on `LabRegistry.__new__` singleton bypass tricks; `LabRegistry` is now always constructed normally (no `__new__` overrides) across the codebase and tests.
- `fastapi_app.lifespan()` skips the startup discovery report entirely when `MAS_CONTROLLER_DISABLE_STARTUP_DISCOVERY` is set, instead of running it and discarding the result.

## Test coverage added

- `mas.registry.list_objects()`: parity with `get()`/`list_names()`, and a single-discovery-pass regression guard.
- `LabRegistry.runtime_objects()`: single-call delegation to `list_objects()`.
- `LabRegistry` manifest cache: reuse across repeated `list_*()` calls, forced rescan on `refresh()` and on `invalidate_manifest_cache()`.
- `ManifestStore.invalidate()` delegation to the injected registry, and registry-injection bypassing the process-wide singleton.
- `ManifestStore.config_files()`: `.yml` (short suffix) files are still discovered under `flavours/` and `infra/` after the 4-scan → 2-scan consolidation.
- `fastapi_app.lifespan()`: discovery skipped when disabled, emitted once when enabled.
- CRUD routes (experiments, pipelines, datasets, overlays): every create/rename/delete is now followed by a re-GET of the list endpoint asserting the change is visible, closing the gap where only disk-level side effects were checked before. Added full CRUD contract coverage for datasets and overlays (previously untested via the FastAPI route layer).

## Testing

`pytest runtime/tests lab/components/controller/tests -q` → 707 passed.
