### PR TITLE
feat: remove delegation cache to enable multi-round convergence

### DIFF
--- a/runtime/src/mas/runtime/boundary/delegation/llm_delegator.py
+++ b/runtime/src/mas/runtime/boundary/delegation/llm_delegator.py
@@ -19,6 +19,9 @@ class LlmDelegator:
         run_turn: RunTurnFn,
     ) -> None:
         self._run_turn = run_turn
+        # Compatibility cache retained for reset/session lifecycle hooks and tests.
+        # Delegations are intentionally executed fresh each round; this cache is only
+        # a bookkeeping record and must never suppress a new call.
         self._completed_peers: dict[tuple[str, str, str], str] = {}
 
     def reset_session(self) -> None:
@@ -44,13 +47,6 @@ class LlmDelegator:
         if not target_agent_id:
             return "[delegation] missing target agent id"
         task_key = task.strip()
-        cache_key = (target_agent_id, task_key, context_id)
-        if cache_key in self._completed_peers:
-            return (
-                f"[delegation] {target_agent_id!r} already consulted this session for "
-                "the same task — use the findings below; call the next specialist instead.\n\n"
-                f"{self._completed_peers[cache_key]}"
-            )
         try:
             result = self._run_turn(
                 target_agent_id, task_key, correlation_id, caller_call_id, context_id
@@ -59,7 +55,10 @@ class LlmDelegator:
             return f"[delegation] agent {target_agent_id!r} not available on bus"
         except RuntimeError as exc:
             return f"[delegation] agent {target_agent_id!r} failed: {exc}"
-        self._completed_peers[cache_key] = result
+
+        # Keep the completion cache for compatibility/reset hooks without blocking
+        # future delegations. Fresh execution remains the source of truth.
+        self._completed_peers[(target_agent_id, task_key, caller_call_id)] = result
         return result
 
     def call_delegate_tool(

--- a/runtime/tests/test_llm_delegator.py
+++ b/runtime/tests/test_llm_delegator.py
@@ -36,7 +36,7 @@ def test_llm_delegator_is_delegate_tool():
     assert not delegator.is_delegate_tool("delegate_to_")
 
 
-def test_llm_delegator_caches_identical_task_per_session():
+def test_llm_delegator_repeats_identical_task_per_session():
     calls: list[str] = []
 
     def run_turn(
@@ -47,10 +47,9 @@ def test_llm_delegator_caches_identical_task_per_session():
 
     delegator = LlmDelegator(run_turn=run_turn)
     assert delegator.delegate("telemetry", "task1") == "findings:telemetry:task1"
-    cached = delegator.delegate("telemetry", "task1")
-    assert "already consulted" in cached
-    assert "findings:telemetry:task1" in cached
-    assert calls == ["telemetry"]
+    repeated = delegator.delegate("telemetry", "task1")
+    assert repeated == "findings:telemetry:task1"
+    assert calls == ["telemetry", "telemetry"]
 
 
 def test_llm_delegator_different_tasks_call_peer_again():


### PR DESCRIPTION
## Summary

- Remove the per-session delegation dedupe behavior in [runtime/src/mas/runtime/boundary/delegation/llm_delegator.py](runtime/src/mas/runtime/boundary/delegation/llm_delegator.py) so identical delegate requests can execute again across rounds.
- Keep the internal completion map only as compatibility bookkeeping for lifecycle/reset behavior; it no longer suppresses fresh delegate calls.

## Why

The previous already-consulted cache prevented repeated delegation for the same target/task within a session, which blocks multi-round convergence workflows where revisiting the same specialist is expected.

## Tests

- Updated [runtime/tests/test_llm_delegator.py](runtime/tests/test_llm_delegator.py) to assert repeated identical tasks execute again (no cache short-circuit).
- Validation run:
  - `pytest runtime/tests -q --tb=short` -> 532 passed
  - `pytest runtime/tests lab/components/controller/tests -q --tb=short` -> 707 passed

## Branch shape

- Single commit on top of `origin/main`
- Ahead/behind vs `origin/main`: 1/0
