### PR TITLE
feat(runtime): drop remaining delegator completed-peers bookkeeping state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b "${{ runner.temp }}/bin"
           echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
 
-      - name: CI gates (Taskfile ci = verify:literals + verify-unit + verify-functional + validate)
+      - name: CI gates (Taskfile ci = verify:literals + verify-unit + verify-controller + verify-functional + validate + verify-chat-smoke + verify-hitl-gate)
         run: task ci
 
       - name: Coverage gate (kernel, ctl.workspace, bench pipeline)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -111,7 +111,7 @@ tasks:
       - task: verify-tutorials
 
   ci:
-    desc: "CI parity — same gates as .github/workflows/test.yml (unit + functional + dry-run)"
+    desc: "CI parity — same gates as .github/workflows/test.yml (unit + functional + dry-run + chat smoke + HITL)"
     deps: [install-dev]
     cmds:
       - task: verify:literals
@@ -119,6 +119,8 @@ tasks:
       - task: verify-controller
       - task: verify-functional
       - task: validate
+      - task: verify-chat-smoke
+      - task: verify-hitl-gate
 
   ci-fast:
     desc: "Fast CI — literals + unit gate only (skips slow functional/dry-run gates)."
@@ -169,14 +171,12 @@ tasks:
           -o overlays/governance-hitl.yaml
 
   verify:
-    desc: "Full pre-commit gate — CI gates + env check, version check, chat smoke, HITL"
+    desc: "Full pre-commit gate — CI gates + local env check, version check"
     deps: [install-dev]
     cmds:
       - python3 scripts/version_manager.py check
       - task: verify-ctl-env
       - task: ci
-      - task: verify-chat-smoke
-      - task: verify-hitl-gate
 
   test:
     desc: "Run full verify suite (verbose tutorials)"

--- a/ctl/tests/test_mas_agent_merge.py
+++ b/ctl/tests/test_mas_agent_merge.py
@@ -185,20 +185,28 @@ def test_wire_entry_engine_delegation_enables_tool_loop_on_leaf():
     assert inner.manifest is manifest
 
 
-def test_reset_engine_delegation_clears_delegate_cache():
+def test_reset_engine_delegation_does_not_suppress_repeated_delegation():
     from mas.runtime.boundary.delegation.llm_delegator import LlmDelegator
 
     from mas.ctl.manifest.mas_agent_merge import reset_engine_delegation
 
+    calls: list[str] = []
+
+    def run_turn(
+        agent_id: str, task: str, correlation_id: int, caller_call_id: str, context_id: str
+    ) -> str:
+        calls.append(agent_id)
+        return f"findings:{agent_id}:{task}"
+
     class _Engine:
         def __init__(self) -> None:
-            self.delegation = LlmDelegator(run_turn=lambda _a, _t, _c, _ccid, _ctx_id: "ok")
+            self.delegation = LlmDelegator(run_turn=run_turn)
 
     engine = _Engine()
-    engine.delegation.delegate("peer", "task")
-    assert ("peer", "task", "") in engine.delegation._completed_peers
+    assert engine.delegation.delegate("peer", "task") == "findings:peer:task"
     reset_engine_delegation(engine)
-    assert not engine.delegation._completed_peers
+    assert engine.delegation.delegate("peer", "task") == "findings:peer:task"
+    assert calls == ["peer", "peer"]
 
 
 def test_apply_agency_entry_overlay_merges_context_and_tools():

--- a/runtime/src/mas/runtime/boundary/delegation/llm_delegator.py
+++ b/runtime/src/mas/runtime/boundary/delegation/llm_delegator.py
@@ -19,14 +19,10 @@ class LlmDelegator:
         run_turn: RunTurnFn,
     ) -> None:
         self._run_turn = run_turn
-        # Compatibility cache retained for reset/session lifecycle hooks and tests.
-        # Delegations are intentionally executed fresh each round; this cache is only
-        # a bookkeeping record and must never suppress a new call.
-        self._completed_peers: dict[tuple[str, str, str], str] = {}
 
     def reset_session(self) -> None:
-        """Clear per-session delegate cache (new user incident)."""
-        self._completed_peers.clear()
+        """Compatibility hook retained for lifecycle callers; no cache persists."""
+        return None
 
     def is_delegate_tool(self, tool_name: str) -> bool:
         from mas.runtime.boundary.delegation.policy import DELEGATE_TOOL_PREFIX
@@ -56,9 +52,6 @@ class LlmDelegator:
         except RuntimeError as exc:
             return f"[delegation] agent {target_agent_id!r} failed: {exc}"
 
-        # Keep the completion cache for compatibility/reset hooks without blocking
-        # future delegations. Fresh execution remains the source of truth.
-        self._completed_peers[(target_agent_id, task_key, caller_call_id)] = result
         return result
 
     def call_delegate_tool(


### PR DESCRIPTION
## What

Follow-up to #46.

PR #46 removed the dedupe/suppression logic from `LlmDelegator` but kept `_completed_peers` as a passive "compatibility" record, along with `reset_session()` clearing it and a post-delegate write-back. That leftover state is unused by any caller and no longer serves the multi-round convergence behavior introduced in #46.

- Drop the `_completed_peers` dict, its write-back, and the `reset_session` clear; `reset_session` is now a no-op kept only for lifecycle callers.
- Update `ctl/tests/test_mas_agent_merge.py` to assert on delegate/reset behavior (fresh execution on repeat, no suppression) instead of asserting on the removed attribute's cache contents.

Also move `verify-chat-smoke` and `verify-hitl-gate` from `task verify` into `task ci`, and trim `verify` to its local-only checks (version, ctl-env) plus `ci`. Update the `test.yml` step name to match.

## Testing

```
pytest runtime/tests/test_llm_delegator.py ctl/tests/test_mas_agent_merge.py -q --tb=short
# 28 passed

task ci
# all gates pass, ~1:49
```