### PR TITLE
fix(runtime): honor configured workflow entry

### DIFF
--- a/library-standard/src/mas/library/standard/plugins/design_patterns/base.py
+++ b/library-standard/src/mas/library/standard/plugins/design_patterns/base.py
@@ -120,40 +120,46 @@ class _DeterministicBase(DesignPatternPlugin):
     def _participants_from_spec(self, config: KernelConfig) -> list[str]:
         spec = getattr(config, "agent_spec", None) or {}
         wf = (spec.get("workflow") or {}) if isinstance(spec, dict) else {}
+        entry_id = str(wf.get("entry") or "moderator").strip()
 
-        # 1) moderator.delegates_to (dynamic topology)
+        def participants(values: object) -> list[str]:
+            if not isinstance(values, list):
+                return []
+            return [
+                participant
+                for value in values
+                if (participant := str(value).strip()) and participant != entry_id
+            ]
+
+        # 1) entry node delegates_to (dynamic topology)
         nodes = wf.get("nodes") or []
         for node in nodes:
             if not isinstance(node, dict):
                 continue
-            if str(node.get("id") or "").strip() != "moderator":
+            if str(node.get("id") or "").strip() != entry_id:
                 continue
-            delegates = node.get("delegates_to") or []
-            if isinstance(delegates, list):
-                out = [str(x).strip() for x in delegates if str(x).strip()]
-                if out:
-                    return out
-
-        # 2) explicit workflow.participants
-        participants = wf.get("participants") or []
-        if isinstance(participants, list):
-            out = [str(x).strip() for x in participants if str(x).strip()]
+            out = participants(node.get("delegates_to") or [])
             if out:
                 return out
 
-        # 3) fallback: workflow.nodes excluding moderator
+        # 2) explicit workflow.participants
+        out = participants(wf.get("participants") or [])
+        if out:
+            return out
+
+        # 3) fallback: workflow.nodes excluding the entry agent
         out: list[str] = []
         for node in nodes:
             if not isinstance(node, dict):
                 continue
             node_id = str(node.get("id") or node.get("agent") or "").strip()
-            if not node_id or node_id == "moderator":
+            if not node_id or node_id == entry_id:
                 continue
             out.append(node_id)
         if out:
             return out
 
-        # 4) fallback: agency agents list from MAS spec (exclude moderator/self)
+        # 4) fallback: agency agents list from MAS spec (exclude entry/self)
         agency = (spec.get("agency") or {}) if isinstance(spec, dict) else {}
         rows = agency.get("agents") or []
         out = []
@@ -161,7 +167,7 @@ class _DeterministicBase(DesignPatternPlugin):
             if not isinstance(row, dict):
                 continue
             aid = str(row.get("id") or row.get("name") or "").strip()
-            if not aid or aid == "moderator":
+            if not aid or aid == entry_id:
                 continue
             out.append(aid)
         return out

--- a/library-standard/tests/test_deterministic_patterns.py
+++ b/library-standard/tests/test_deterministic_patterns.py
@@ -1,0 +1,82 @@
+from mas.library.standard.plugins.design_patterns.parallel import (
+    DeterministicParallelPlugin,
+)
+from mas.runtime.kernel.config import KernelConfig
+
+
+def _participants(agent_spec: dict) -> list[str]:
+    config = KernelConfig(agent_spec=agent_spec)
+    return DeterministicParallelPlugin()._participants_from_spec(config)
+
+
+def test_participants_follow_configured_entry_delegates() -> None:
+    assert _participants(
+        {
+            "workflow": {
+                "entry": "sre",
+                "nodes": [
+                    {
+                        "id": "sre",
+                        "delegates_to": ["telemetry", "backend", "verifier"],
+                    },
+                    {"id": "telemetry"},
+                    {"id": "backend"},
+                    {"id": "verifier"},
+                ],
+            }
+        }
+    ) == ["telemetry", "backend", "verifier"]
+
+
+def test_participant_sources_exclude_configured_entry() -> None:
+    assert _participants(
+        {
+            "workflow": {
+                "entry": "lead",
+                "participants": ["lead", "analyst", "verifier"],
+            }
+        }
+    ) == ["analyst", "verifier"]
+
+    assert _participants(
+        {
+            "workflow": {
+                "entry": "lead",
+                "nodes": [
+                    {"id": "lead"},
+                    {"id": "analyst"},
+                    {"id": "verifier"},
+                ],
+            }
+        }
+    ) == ["analyst", "verifier"]
+
+    assert _participants(
+        {
+            "workflow": {"entry": "lead"},
+            "agency": {
+                "agents": [
+                    {"id": "lead"},
+                    {"id": "analyst"},
+                    {"id": "verifier"},
+                ]
+            },
+        }
+    ) == ["analyst", "verifier"]
+
+
+def test_moderator_remains_default_entry() -> None:
+    assert _participants(
+        {
+            "workflow": {
+                "nodes": [
+                    {
+                        "id": "moderator",
+                        "delegates_to": ["analyst", "verifier"],
+                    },
+                    {"id": "analyst"},
+                    {"id": "verifier"},
+                ]
+            }
+        }
+    ) == ["analyst", "verifier"]


### PR DESCRIPTION
## Summary
- resolve deterministic-pattern participants from the configured `workflow.entry` node instead of assuming `moderator`
- exclude the entry agent from delegates, explicit participants, workflow-node fallback, and agency fallback
- preserve `moderator` as the default for existing manifests

## Verification
- `77 passed, 2 skipped` across `library-standard/tests` and the design-pattern integration suite
- live SRE-triage smoke tests for parallel, linear, and staged-debate patterns
- isolated trace verification confirmed no `delegate_to_sre` self-delegation

Related tracking issue: [cisco-eti/ioc-core-mas-lab#34](https://github.com/cisco-eti/ioc-core-mas-lab/issues/34)