### PR TITLE
feat(hitl): add subscribe() to HitlResolverRegistry

### DIFF
--- a/runtime/src/mas/runtime/boundary/hitl/registry.py
+++ b/runtime/src/mas/runtime/boundary/hitl/registry.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -58,7 +59,42 @@ class HitlResolverRegistry:
         # pending[(session_id, agent_id, correlation_id)] = PendingHitlRequest
         self._pending: dict[tuple[str, str, int], PendingHitlRequest] = {}
         self._user_updates: dict[tuple[str, str, int], PendingUserUpdate] = {}
-    
+        # Additive, never-reset subscriber lists -- same pattern as
+        # ObservabilityOperator.subscribe()/KernelDriver.subscribe_exchange():
+        # multiple consumers (e.g. a Webex bot and a CLI console) can each
+        # register once and coexist, instead of one overwriting another.
+        self._hitl_subscribers: list[Callable[[PendingHitlRequest], None]] = []
+        self._user_update_subscribers: list[Callable[[PendingUserUpdate], None]] = []
+
+    def subscribe(self, callback: Callable[[PendingHitlRequest], None]) -> None:
+        """Notify *callback* the instant a HITL request is registered.
+
+        Replaces polling get_pending_for_session() in a retry loop to bridge
+        the gap between "tool call started" (an early, structural signal a
+        caller may see before the request itself exists) and "the request is
+        actually in the registry" (written by the tool's own execution) --
+        subscribers are notified synchronously, inside register(), so there
+        is no such gap to poll around.
+        """
+        with self._lock:
+            if callback not in self._hitl_subscribers:
+                self._hitl_subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[PendingHitlRequest], None]) -> None:
+        with self._lock:
+            if callback in self._hitl_subscribers:
+                self._hitl_subscribers.remove(callback)
+
+    def subscribe_user_update(self, callback: Callable[[PendingUserUpdate], None]) -> None:
+        with self._lock:
+            if callback not in self._user_update_subscribers:
+                self._user_update_subscribers.append(callback)
+
+    def unsubscribe_user_update(self, callback: Callable[[PendingUserUpdate], None]) -> None:
+        with self._lock:
+            if callback in self._user_update_subscribers:
+                self._user_update_subscribers.remove(callback)
+
     def register(
         self,
         *,
@@ -74,7 +110,7 @@ class HitlResolverRegistry:
         """Register a pending HITL request."""
         with self._lock:
             key = (session_id, agent_id, correlation_id)
-            self._pending[key] = PendingHitlRequest(
+            request = PendingHitlRequest(
                 session_id=session_id,
                 agent_id=agent_id,
                 correlation_id=correlation_id,
@@ -84,6 +120,13 @@ class HitlResolverRegistry:
                 context_data=dict(context_data),
                 resolver_callback=resolver_callback,
             )
+            self._pending[key] = request
+            subscribers = list(self._hitl_subscribers)
+        for callback in subscribers:
+            try:
+                callback(request)
+            except Exception:
+                logging.getLogger("mas.runtime").exception("HITL registry subscriber failed")
 
     def register_user_update(
         self,
@@ -99,7 +142,7 @@ class HitlResolverRegistry:
         """Register a non-blocking user update emitted from a delegating agent."""
         with self._lock:
             key = (session_id, agent_id, correlation_id)
-            self._user_updates[key] = PendingUserUpdate(
+            update = PendingUserUpdate(
                 session_id=session_id,
                 agent_id=agent_id,
                 correlation_id=correlation_id,
@@ -108,6 +151,13 @@ class HitlResolverRegistry:
                 involved_agents=list(involved_agents or []),
                 metadata=dict(metadata or {}),
             )
+            self._user_updates[key] = update
+            subscribers = list(self._user_update_subscribers)
+        for callback in subscribers:
+            try:
+                callback(update)
+            except Exception:
+                logging.getLogger("mas.runtime").exception("HITL registry user-update subscriber failed")
     
     def resolve(
         self,

--- a/runtime/tests/test_hitl_registry_subscribe.py
+++ b/runtime/tests/test_hitl_registry_subscribe.py
@@ -1,0 +1,95 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""HitlResolverRegistry.subscribe(): synchronous, additive notification on
+register() -- replaces polling get_pending_for_session() in a retry loop to
+bridge the gap between "tool call started" and "request is in the registry"."""
+
+from __future__ import annotations
+
+from mas.runtime.boundary.hitl.registry import HitlResolverRegistry
+from mas.runtime.schema.hitl import HitlQuestionType
+
+
+def _register(registry: HitlResolverRegistry, *, session_id: str = "s1", correlation_id: int = 1) -> None:
+    registry.register(
+        session_id=session_id,
+        agent_id="finance-agent",
+        correlation_id=correlation_id,
+        question="Approve 20% discount?",
+        question_type=HitlQuestionType.CONFIRM,
+        choices=["approve", "reject"],
+        context_data={},
+    )
+
+
+def test_subscriber_notified_synchronously_on_register():
+    registry = HitlResolverRegistry()
+    received = []
+    registry.subscribe(received.append)
+
+    _register(registry)
+
+    assert len(received) == 1
+    assert received[0].question == "Approve 20% discount?"
+
+
+def test_multiple_subscribers_all_notified():
+    registry = HitlResolverRegistry()
+    a, b = [], []
+    registry.subscribe(a.append)
+    registry.subscribe(b.append)
+
+    _register(registry)
+
+    assert len(a) == 1 and len(b) == 1
+
+
+def test_unsubscribe_stops_notifications():
+    registry = HitlResolverRegistry()
+    received = []
+    registry.subscribe(received.append)
+    registry.unsubscribe(received.append)
+
+    _register(registry)
+
+    assert received == []
+
+
+def test_subscribing_same_callback_twice_is_a_noop():
+    registry = HitlResolverRegistry()
+    received = []
+    registry.subscribe(received.append)
+    registry.subscribe(received.append)
+
+    _register(registry)
+
+    assert len(received) == 1
+
+
+def test_subscriber_exception_does_not_break_registration_or_other_subscribers():
+    registry = HitlResolverRegistry()
+    received = []
+
+    def boom(_request):
+        raise RuntimeError("boom")
+
+    registry.subscribe(boom)
+    registry.subscribe(received.append)
+
+    _register(registry)
+
+    assert len(received) == 1
+    assert registry.has_pending("s1", "finance-agent")
+
+
+def test_user_update_subscriber_notified_on_register_user_update():
+    registry = HitlResolverRegistry()
+    received = []
+    registry.subscribe_user_update(received.append)
+
+    registry.register_user_update(
+        session_id="s1", agent_id="moderator", correlation_id=1, message="Checking with Finance..."
+    )
+
+    assert len(received) == 1
+    assert received[0].message == "Checking with Finance..."


### PR DESCRIPTION
- HitlResolverRegistry.subscribe()/unsubscribe() (and the ...user_update
  counterparts) let one or more callbacks be notified the instant a HITL
  request is registered -- synchronously, inside register() itself.
- Replaces polling get_pending_for_session() in a retry loop: that pattern
  had a real gap between "a tool call started" (an early, structural
  signal a caller might see before the request itself exists) and "the
  request actually exists" (written by the tool's own execution), so a
  consumer had to poll and hope. Subscribers now see the request the
  moment it's written, no gap to poll around.
- Additive and never-reset -- the same pattern as ObservabilityOperator.
  subscribe() and KernelDriver.subscribe_exchange() -- so more than one
  consumer (e.g. a Webex bot and a CLI console) can each subscribe once
  and coexist, instead of one overwriting another.
