### PR TITLE
feat(runtime): stream LLM responses over SSE

### DIFF
--- a/ctl/src/mas/ctl/cli/commands/chat.py
+++ b/ctl/src/mas/ctl/cli/commands/chat.py
@@ -72,6 +72,12 @@ from mas.ctl.ui.stdout import StdoutConversationDisplay
     "(default: spec.execution.cache.write / MAS_LLM_CACHE_WRITE / true)",
 )
 @click.option(
+    "--stream/--no-stream",
+    default=None,
+    help="Stream the LLM response over SSE instead of waiting for the full "
+    "completion (default: spec.execution.stream / MAS_LLM_STREAM / false)",
+)
+@click.option(
     "--without-obs",
     is_flag=True,
     help="Disable envelope observability summand (M_obs) and event recording",
@@ -111,6 +117,7 @@ def chat_cmd(
     no_validate: bool,
     cache_read: bool | None,
     cache_write: bool | None,
+    stream: bool | None,
     without_obs: bool,
     without_gov: bool,
     events: bool | None,
@@ -211,6 +218,7 @@ def chat_cmd(
                     validate_manifests=not no_validate,
                     cache_read_override=cache_read,
                     cache_write_override=cache_write,
+                    stream_override=stream,
                     agent_manifest=agent_data,
                     manifest_dir=session.manifest_dir if manifest else None,
                     resolved_infra=resolve_session_infra(

--- a/ctl/src/mas/ctl/session/bootstrap.py
+++ b/ctl/src/mas/ctl/session/bootstrap.py
@@ -66,6 +66,7 @@ class InstantiationOptions:
     user_io_contract: object | None = None
     cache_read_override: bool | None = None
     cache_write_override: bool | None = None
+    stream_override: bool | None = None
 
 
 def instantiate_runtime(
@@ -148,6 +149,7 @@ def instantiate_runtime(
         kernel_config=_kernel_cfg,
         cache_read_override=options.cache_read_override,
         cache_write_override=options.cache_write_override,
+        stream_override=options.stream_override,
     )
     logger.info("Engine mode=%s (%s)", selection.mode, selection.reason)
 

--- a/ctl/src/mas/ctl/session/engine_factory.py
+++ b/ctl/src/mas/ctl/session/engine_factory.py
@@ -128,6 +128,7 @@ def build_engine(
     kernel_config: KernelConfig | None = None,
     cache_read_override: bool | None = None,
     cache_write_override: bool | None = None,
+    stream_override: bool | None = None,
 ) -> EngineSelection:
     pid = pattern_plugin_id or default_pattern_plugin_id()
     # Use pre-parsed kernel config if provided (spec-aware path); fall back to manifest parsing.
@@ -170,6 +171,7 @@ def build_engine(
     cache_write = _cache_write_enabled(manifest, override=cache_write_override)
     cache_active = (cache_read or cache_write) and not mock and not (llm_proxy.get("pipeline"))
     cache_path = Path(str(cache_raw)) if cache_raw else resolve_cache_path() if cache_active else None
+    stream = _stream_enabled(manifest, override=stream_override)
 
     engine = _wrap_with_infra_pipeline(
         LiveLlmEngine(
@@ -184,6 +186,7 @@ def build_engine(
             use_cache=cache_active,
             cache_read=cache_read,
             cache_write=cache_write,
+            stream=stream,
             use_tool_loop=tool_loop,
             parallel_tool_calls=kernel_cfg.parallel_tool_calls,
             llm_proxy=llm_proxy,
@@ -259,6 +262,24 @@ def _cache_write_enabled(manifest: dict | None, *, override: bool | None = None)
     if env is not None:
         return env
     return True
+
+
+def _stream_enabled(manifest: dict | None, *, override: bool | None = None) -> bool:
+    """Whether to stream the LLM response over SSE instead of waiting for
+    the full completion. Precedence: explicit CLI override -> spec.execution.
+    stream -> MAS_LLM_STREAM env var -> default false (opt-in: streaming
+    changes what a caller can observe mid-call, e.g. via ctx.on_stream_chunk,
+    so it shouldn't turn on silently for an existing deployment)."""
+    if override is not None:
+        return override
+    spec = (manifest or {}).get("spec") or {}
+    execution = spec.get("execution") or {}
+    if isinstance(execution.get("stream"), bool):
+        return execution["stream"]
+    env = _bool_env("MAS_LLM_STREAM")
+    if env is not None:
+        return env
+    return False
 
 
 def _wrap_with_infra_pipeline(engine: Any, pipeline: list[dict[str, Any]]) -> Any:

--- a/docs/schemas/runtime/fragments/execution-binding.schema.yaml
+++ b/docs/schemas/runtime/fragments/execution-binding.schema.yaml
@@ -33,6 +33,12 @@ properties:
     type: boolean
   live:
     type: boolean
+  stream:
+    type: boolean
+    description: >
+      Stream the LLM response over SSE instead of waiting for the full
+      completion, forwarding content deltas to ctx.on_stream_chunk as they
+      arrive. Default: false.
   timeout:
     type: number
     minimum: 0

--- a/runtime/src/mas/runtime/engine/llm_live.py
+++ b/runtime/src/mas/runtime/engine/llm_live.py
@@ -53,6 +53,7 @@ class LiveLlmEngine:
     use_cache: bool = True
     cache_read: bool = True
     cache_write: bool = True
+    stream: bool = False
     use_tool_loop: bool = False
     parallel_tool_calls: bool = True
     llm_proxy: dict[str, Any] | None = None
@@ -437,6 +438,8 @@ class LiveLlmEngine:
             "Content-Type": "application/json",
         }
         verify = resolve_ssl_verify(self.llm_proxy)
+        if self.stream:
+            return self._chat_completion_streamed(url, payload, headers, verify=verify)
         with httpx.Client(timeout=120.0, verify=verify) as client:
             resp = client.post(url, json=payload, headers=headers)
             resp.raise_for_status()
@@ -449,6 +452,97 @@ class LiveLlmEngine:
         if usage:
             message["usage"] = usage
         finish_reason = choices[0].get("finish_reason")
+        if finish_reason:
+            message["finish_reason"] = finish_reason
+        return message
+
+    def _chat_completion_streamed(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+        *,
+        verify: Any,
+    ) -> dict[str, Any]:
+        """SSE-streamed variant of _chat_completion, same OpenAI-compatible
+        endpoint with ``stream: true``.
+
+        Reassembles the same message shape ({"content", "tool_calls",
+        "usage", "finish_reason"}) the non-streamed path returns, so nothing
+        downstream (_message_to_engine_return, caching) needs to know
+        streaming happened -- the only externally visible difference is that
+        content deltas are also forwarded, as they arrive, to
+        ``ctx.on_stream_chunk(text)`` if the caller set one (a plain
+        attribute read fresh per call, not a constructor field, so a caller
+        like a chat UI can install/replace it per turn without touching
+        engine construction).
+
+        Tool-call argument deltas are accumulated but never forwarded to
+        on_stream_chunk (only content text is): reconstructing valid partial
+        JSON mid-stream is unreliable and not what a "show the answer as
+        it's typed" UI wants anyway.
+        """
+        import httpx
+
+        stream_payload = dict(payload)
+        stream_payload["stream"] = True
+        on_chunk = getattr(self.ctx, "on_stream_chunk", None) if self.ctx is not None else None
+
+        content_parts: list[str] = []
+        tool_call_accum: dict[int, dict[str, Any]] = {}
+        finish_reason = ""
+        usage: dict[str, Any] = {}
+
+        with httpx.Client(timeout=120.0, verify=verify) as client:
+            with client.stream("POST", url, json=stream_payload, headers=headers) as resp:
+                resp.raise_for_status()
+                for raw_line in resp.iter_lines():
+                    line = raw_line if isinstance(raw_line, str) else raw_line.decode("utf-8", "replace")
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:") :].strip()
+                    if not data_str or data_str == "[DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(data_str)
+                    except (TypeError, ValueError):
+                        continue
+                    if isinstance(chunk.get("usage"), dict):
+                        usage = chunk["usage"]
+                    choices = chunk.get("choices") or []
+                    if not choices:
+                        continue
+                    choice = choices[0]
+                    fr = choice.get("finish_reason")
+                    if fr:
+                        finish_reason = fr
+                    delta = choice.get("delta") or {}
+                    text = delta.get("content")
+                    if text:
+                        content_parts.append(text)
+                        if callable(on_chunk):
+                            try:
+                                on_chunk(text)
+                            except Exception:
+                                logger.exception("on_stream_chunk callback failed")
+                    for tc in delta.get("tool_calls") or []:
+                        idx = int(tc.get("index", 0) or 0)
+                        slot = tool_call_accum.setdefault(
+                            idx, {"id": "", "type": "function", "function": {"name": "", "arguments": ""}}
+                        )
+                        if tc.get("id"):
+                            slot["id"] = tc["id"]
+                        fn = tc.get("function") or {}
+                        if fn.get("name"):
+                            slot["function"]["name"] += fn["name"]
+                        if fn.get("arguments"):
+                            slot["function"]["arguments"] += fn["arguments"]
+
+        message: dict[str, Any] = {"content": "".join(content_parts) or None}
+        if tool_call_accum:
+            message["tool_calls"] = [tool_call_accum[i] for i in sorted(tool_call_accum)]
+        if usage:
+            message["usage"] = usage
         if finish_reason:
             message["finish_reason"] = finish_reason
         return message

--- a/runtime/tests/test_llm_live_streaming.py
+++ b/runtime/tests/test_llm_live_streaming.py
@@ -1,0 +1,199 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""LiveLlmEngine streaming: reassembles the same message shape the
+non-streamed path returns, forwarding content deltas to ctx.on_stream_chunk
+as they arrive."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mas.runtime.engine.llm_live import LiveLlmEngine
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+    def __enter__(self) -> "_FakeStreamResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self, lines: list[str], **_: object) -> None:
+        self._lines = lines
+
+    def stream(self, method: str, url: str, *, json: object, headers: object):
+        assert method == "POST"
+        return _FakeStreamResponse(self._lines)
+
+    def __enter__(self) -> "_FakeClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def _sse(chunk: dict) -> str:
+    return f"data: {json.dumps(chunk)}"
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    monkeypatch.setattr("httpx.Client", lambda **kwargs: _FakeClient(lines, **kwargs))
+
+
+def test_streamed_content_is_reassembled_and_forwarded_chunk_by_chunk(monkeypatch):
+    lines = [
+        _sse({"choices": [{"delta": {"content": "Hel"}}]}),
+        _sse({"choices": [{"delta": {"content": "lo, "}}]}),
+        _sse({"choices": [{"delta": {"content": "world."}, "finish_reason": "stop"}]}),
+        _sse({"usage": {"total_tokens": 7}}),
+        "data: [DONE]",
+    ]
+    _install_fake_client(monkeypatch, lines)
+
+    received: list[str] = []
+    ctx = SimpleNamespace(on_stream_chunk=received.append)
+    engine = LiveLlmEngine(ctx=ctx, stream=True, use_cache=False)
+
+    message = engine._chat_completion(
+        [{"role": "user", "content": "hi"}], api_key="k", tools=None
+    )
+
+    assert received == ["Hel", "lo, ", "world."]
+    assert message["content"] == "Hello, world."
+    assert message["finish_reason"] == "stop"
+    assert message["usage"] == {"total_tokens": 7}
+    assert "tool_calls" not in message
+
+
+def test_streamed_tool_calls_are_accumulated_across_chunks_and_not_forwarded(monkeypatch):
+    lines = [
+        _sse(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "id": "call_1", "function": {"name": "get_", "arguments": ""}}
+                            ]
+                        }
+                    }
+                ]
+            }
+        ),
+        _sse(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [{"index": 0, "function": {"name": "weather", "arguments": '{"city":'}}]
+                        }
+                    }
+                ]
+            }
+        ),
+        _sse(
+            {
+                "choices": [
+                    {
+                        "delta": {"tool_calls": [{"index": 0, "function": {"arguments": '"Paris"}'}}]},
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+        ),
+        "data: [DONE]",
+    ]
+    _install_fake_client(monkeypatch, lines)
+
+    received: list[str] = []
+    ctx = SimpleNamespace(on_stream_chunk=received.append)
+    engine = LiveLlmEngine(ctx=ctx, stream=True, use_cache=False)
+
+    message = engine._chat_completion(
+        [{"role": "user", "content": "weather in paris"}], api_key="k", tools=[{"type": "function"}]
+    )
+
+    assert received == []  # tool-call arg deltas are never forwarded as chunks
+    assert message["content"] is None
+    assert message["tool_calls"] == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+        }
+    ]
+    assert message["finish_reason"] == "tool_calls"
+
+
+def test_streaming_works_with_no_on_stream_chunk_installed(monkeypatch):
+    lines = [_sse({"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]}), "data: [DONE]"]
+    _install_fake_client(monkeypatch, lines)
+
+    engine = LiveLlmEngine(ctx=SimpleNamespace(), stream=True, use_cache=False)
+    message = engine._chat_completion([{"role": "user", "content": "hi"}], api_key="k", tools=None)
+
+    assert message["content"] == "ok"
+
+
+def test_streaming_with_no_ctx_at_all(monkeypatch):
+    lines = [_sse({"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]}), "data: [DONE]"]
+    _install_fake_client(monkeypatch, lines)
+
+    engine = LiveLlmEngine(ctx=None, stream=True, use_cache=False)
+    message = engine._chat_completion([{"role": "user", "content": "hi"}], api_key="k", tools=None)
+
+    assert message["content"] == "ok"
+
+
+def test_on_stream_chunk_exception_does_not_break_the_call(monkeypatch):
+    lines = [
+        _sse({"choices": [{"delta": {"content": "a"}}]}),
+        _sse({"choices": [{"delta": {"content": "b"}, "finish_reason": "stop"}]}),
+        "data: [DONE]",
+    ]
+    _install_fake_client(monkeypatch, lines)
+
+    def boom(_chunk: str) -> None:
+        raise RuntimeError("boom")
+
+    engine = LiveLlmEngine(ctx=SimpleNamespace(on_stream_chunk=boom), stream=True, use_cache=False)
+    message = engine._chat_completion([{"role": "user", "content": "hi"}], api_key="k", tools=None)
+
+    assert message["content"] == "ab"
+
+
+def test_ignores_malformed_and_empty_sse_lines(monkeypatch):
+    lines = [
+        "",
+        "event: ping",
+        "data: not-json",
+        _sse({"choices": [{"delta": {"content": "fine"}, "finish_reason": "stop"}]}),
+        "data: [DONE]",
+    ]
+    _install_fake_client(monkeypatch, lines)
+
+    engine = LiveLlmEngine(ctx=SimpleNamespace(), stream=True, use_cache=False)
+    message = engine._chat_completion([{"role": "user", "content": "hi"}], api_key="k", tools=None)
+
+    assert message["content"] == "fine"
+
+
+def test_non_streaming_path_is_unaffected_by_stream_field_default(monkeypatch):
+    """stream defaults to False -- the existing non-streamed path (already
+    covered elsewhere) must still be the one used unless explicitly opted in."""
+    engine = LiveLlmEngine(use_cache=False)
+    assert engine.stream is False


### PR DESCRIPTION
- LiveLlmEngine.stream (spec.execution.stream / MAS_LLM_STREAM /
  --stream on mas-ctl chat, default false) switches a chat completion
  call to Server-Sent Events, forwarding content deltas live to
  ctx.on_stream_chunk(text) as they arrive.
- The final message shape ({"content", "tool_calls", "usage",
  "finish_reason"}) is reassembled identically to the non-streamed path,
  so nothing downstream (caching, tool dispatch) needs to know streaming
  happened -- only content deltas are forwarded early, before the full
  response completes.
- ctx.on_stream_chunk is a plain attribute read fresh per call, not a
  constructor field, so a caller (e.g. a chat UI) can install or replace
  it per turn without touching engine construction.
- Tool-call argument deltas are accumulated but never forwarded chunk by
  chunk -- reconstructing valid partial JSON mid-stream is unreliable,
  and not what a "show the answer as it's typed" UI wants from a tool
  call anyway.
