### PR TITLE
fix: keep tool_calls/tool_result pairs when trimming conversation

### DIFF
--- a/library-standard/src/mas/library/standard/plugins/context/conversation.py
+++ b/library-standard/src/mas/library/standard/plugins/context/conversation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
+from mas.library.standard.plugins.context.tool_pairing import group_exchanges, skip_tool_group
 from mas.runtime.contracts.context_manager_contract import ContextManagerContract
 
 _log = logging.getLogger(__name__)
@@ -29,13 +30,20 @@ class StackConversation(ContextManagerContract):
             return past
         if len(past) <= self.max_messages:
             return past
-        evicted = len(past) - self.max_messages
+
+        tail = list(past)
+        while len(tail) > self.max_messages:
+            n = skip_tool_group(tail, 0)
+            if n >= len(tail):
+                break
+            del tail[:n]
+
         _log.debug(
             "StackConversation: evicted %d message(s), keeping last %d",
-            evicted,
-            self.max_messages,
+            len(past) - len(tail),
+            len(tail),
         )
-        return past[-self.max_messages :]
+        return tail
 
 
 class SlidingWindowConversation(ContextManagerContract):
@@ -54,21 +62,7 @@ class SlidingWindowConversation(ContextManagerContract):
         if not past:
             return past
 
-        exchanges: list[list[dict[str, Any]]] = []
-        i = 0
-        while i < len(past):
-            msg = past[i]
-            if msg.get("role") == "user":
-                exchange: list[dict[str, Any]] = [msg]
-                if i + 1 < len(past) and past[i + 1].get("role") == "assistant":
-                    exchange.append(past[i + 1])
-                    i += 2
-                else:
-                    i += 1
-                exchanges.append(exchange)
-            else:
-                exchanges.append([msg])
-                i += 1
+        exchanges = group_exchanges(past)
 
         if len(exchanges) <= self.max_turns:
             return past
@@ -123,21 +117,7 @@ class SummarizingConversation(ContextManagerContract):
         if self._estimate_tokens(past) <= effective:
             return past
 
-        exchanges: list[list[dict[str, Any]]] = []
-        i = 0
-        while i < len(past):
-            msg = past[i]
-            if msg.get("role") == "user":
-                exchange: list[dict[str, Any]] = [msg]
-                if i + 1 < len(past) and past[i + 1].get("role") == "assistant":
-                    exchange.append(past[i + 1])
-                    i += 2
-                else:
-                    i += 1
-                exchanges.append(exchange)
-            else:
-                exchanges.append([msg])
-                i += 1
+        exchanges = group_exchanges(past)
 
         if len(exchanges) <= self.keep_turns:
             return past

--- a/library-standard/src/mas/library/standard/plugins/context/token_budget.py
+++ b/library-standard/src/mas/library/standard/plugins/context/token_budget.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from mas.library.standard.plugins.context.tool_pairing import skip_tool_group as _skip_tool_group
+
 
 def estimate_tokens(messages: list[dict[str, Any]]) -> int:
     total = 0
@@ -17,29 +19,6 @@ def estimate_tokens(messages: list[dict[str, Any]]) -> int:
             fn = call.get("function") or {}
             total += len(str(fn.get("name", ""))) + len(str(fn.get("arguments", "")))
     return total // 4 + len(messages) * 4
-
-
-def _skip_tool_group(tail: list[dict[str, Any]], start: int) -> int:
-    """Return how many messages to drop starting at *start* to keep tool pairs intact.
-
-    If ``tail[start]`` is an assistant message with ``tool_calls``, we must also
-    drop every subsequent ``tool`` response that references one of those calls.
-    If ``tail[start]`` is an orphaned ``tool`` message, drop it too.
-    """
-    msg = tail[start]
-    if msg.get("role") == "assistant" and msg.get("tool_calls"):
-        call_ids = {c.get("id") for c in msg["tool_calls"] if c.get("id")}
-        count = 1
-        while start + count < len(tail):
-            nxt = tail[start + count]
-            if nxt.get("role") == "tool" and nxt.get("tool_call_id") in call_ids:
-                count += 1
-            else:
-                break
-        return count
-    if msg.get("role") == "tool":
-        return 1
-    return 1
 
 
 def trim_messages_to_budget(

--- a/library-standard/src/mas/library/standard/plugins/context/tool_pairing.py
+++ b/library-standard/src/mas/library/standard/plugins/context/tool_pairing.py
@@ -1,0 +1,51 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for trimming message lists without splitting tool_calls/tool pairs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def skip_tool_group(messages: list[dict[str, Any]], start: int) -> int:
+    """Return how many messages to drop starting at *start* to keep tool pairs intact.
+
+    If ``messages[start]`` is an assistant message with ``tool_calls``, every
+    subsequent ``tool`` response that references one of those calls is dropped
+    with it. An orphaned ``tool`` message is dropped alone.
+    """
+    msg = messages[start]
+    if msg.get("role") == "assistant" and msg.get("tool_calls"):
+        call_ids = {c.get("id") for c in msg["tool_calls"] if c.get("id")}
+        count = 1
+        while start + count < len(messages):
+            nxt = messages[start + count]
+            if nxt.get("role") == "tool" and nxt.get("tool_call_id") in call_ids:
+                count += 1
+            else:
+                break
+        return count
+    return 1
+
+
+def group_exchanges(past: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Group messages into user/assistant exchanges, keeping tool_calls/tool pairs atomic."""
+    exchanges: list[list[dict[str, Any]]] = []
+    i = 0
+    while i < len(past):
+        msg = past[i]
+        if msg.get("role") == "user":
+            exchange = [msg]
+            i += 1
+            if i < len(past) and past[i].get("role") == "assistant":
+                exchange.append(past[i])
+                i += 1
+                n = skip_tool_group(past, i - 1) - 1  # trailing tool results, if any
+                exchange.extend(past[i : i + n])
+                i += n
+            exchanges.append(exchange)
+        else:
+            n = skip_tool_group(past, i)
+            exchanges.append(past[i : i + n])
+            i += n
+    return exchanges


### PR DESCRIPTION
## Problem

Long-running agent conversations that exceed the configured history limit
(`max_messages`, `max_turns`, or the token budget) get trimmed by one of the
`context_manager` strategies (`StackConversation`, `SlidingWindowConversation`,
`SummarizingConversation`). All three cut the message list at a positional
boundary with no awareness of tool-call structure, so a truncation could land
between an assistant `tool_calls` message and its matching `tool` result,
sending one without the other.

Bedrock function-calling APIs reject that outright:

```
BedrockException - Expected toolResult blocks at messages.0.content for the following Ids: call_2
```

This surfaced in long-running multi-turn agents (e.g. a CONCORD consensus negotiation),
eventually exhausting the LLM call's fallback chain and failing the whole
benchmark run.

`token_budget.py` `trim_messages_to_budget` already handled this correctly
via a private `_skip_tool_group` helper — it just wasn't shared with the
other three strategies.

## Fix

- Add `library-standard/.../plugins/context/tool_pairing.py` with two shared
  helpers:
  - `skip_tool_group(messages, start)` — returns how many messages must be
    evicted together as one atomic unit (an assistant `tool_calls` message
    plus every `tool` response that references one of those call ids).
  - `group_exchanges(past)` — builds turn-level exchange groups for
    windowing, folding trailing tool call/result messages into the exchange
    they belong to instead of splitting them into their own single-message
    exchanges.
- `token_budget.py` now imports `skip_tool_group` from the shared module
  instead of keeping a private duplicate (no behavior change).
- `StackConversation.manage_history` now evicts from the front in
  tool-call-atomic units instead of a raw `past[-max_messages:]` slice.
- `SlidingWindowConversation` and `SummarizingConversation` now build their
  exchange groups via `group_exchanges`, so slicing by turn count can never
  land inside a tool_calls/tool_result pair.

## Testing

- Existing test suite passes unchanged (`runtime/tests`, `library-standard/tests`).
- Added a manual repro scenario (tool_calls immediately followed by its
  result, landing exactly on a trim boundary) confirming no orphaned `tool`
  message reaches position 0 after trimming, for both `StackConversation`
  and `SlidingWindowConversation`.
- Re-ran the failing benchmark scenario end-to-end; the Bedrock
  `Expected toolResult blocks` error no longer occurs across 5 consecutive
  runs.