### PR TITLE
fix(skills): reach the git root's own skills/ dir in ancestor walk-up

### DIFF
--- a/library-skills/agentskills/src/agentskills/discovery.py
+++ b/library-skills/agentskills/src/agentskills/discovery.py
@@ -197,7 +197,9 @@ class Discovery:
     def _walk_ancestors(self, start: Path, seen: dict[Path, None]) -> None:
         """Walk up the directory tree looking for skills/ directories.
 
-        Stops at git root (or after ancestor_walk_depth levels, if set).
+        Includes the git root's own skills/ dir (monorepo-shared skills live
+        there), then stops. Also stops after ancestor_walk_depth levels, if
+        set.
         """
         try:
             git_root = Path(
@@ -213,9 +215,6 @@ class Discovery:
             git_root = None
 
         for depth, parent in enumerate(start.resolve().parents):
-            # Stop at git root or depth limit
-            if git_root and parent == git_root:
-                break
             if (
                 self.ancestor_walk_depth is not None
                 and depth > self.ancestor_walk_depth
@@ -226,6 +225,11 @@ class Discovery:
             r = p_skills.resolve()
             if r not in seen and r.exists():
                 seen[r] = None
+
+            # Stop after processing git root — its skills/ dir (just above)
+            # is the last stop for a monorepo walk-up.
+            if git_root and parent == git_root:
+                break
 
     def _classify_scope(self, skill_path: Path) -> str:
         """Classify skill as 'project', 'user', or 'builtin'."""

--- a/library-skills/docs/spec-coverage.md
+++ b/library-skills/docs/spec-coverage.md
@@ -25,7 +25,7 @@ Legend: ✅ Implemented · ⚠️ Partial · ❌ Not yet · 🔲 Out of scope
 | User-level `~/.agents/skills/` | ✅ | Included in search roots |
 | MAS Lab user-level `~/.mas/skills/` | ✅ | Included in search roots |
 | Client-specific `~/.<client>/skills/` | ❌ | Not implemented; use `.agents/skills/` |
-| Ancestor dirs up to git root (monorepo) | ❌ | Walk-up stops at first `skills/` found |
+| Ancestor dirs up to git root (monorepo) | ✅ | `agentskills.discovery.Discovery._walk_ancestors()` walks up to and including the git root's own `skills/` dir |
 | XDG config directory scan | ❌ | Not implemented |
 | Scan depth / directory bounds | ❌ | No max-depth guard (not yet needed at manifest-ref scale) |
 | Skip `.git`, `node_modules` | ❌ | Not needed at manifest-ref scale |

--- a/library-skills/tests/test_discovery_ancestor_walk.py
+++ b/library-skills/tests/test_discovery_ancestor_walk.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Ancestor-dir walk-up must reach the git root's own skills/ dir.
+
+Regression coverage for the monorepo-shared-skills gap: the walk used to stop
+exactly at the git root boundary, before checking that directory's own
+`skills/` subfolder, so a root-level `<repo>/skills/` was never found from an
+app nested a few levels below it. See docs/spec-coverage.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from agentskills import Discovery
+
+from .conftest import make_skill
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+
+
+def test_walk_up_finds_git_root_skills_dir(tmp_path: Path):
+    """A skill living only in <git_root>/skills/ is discoverable from a
+    nested app dir that has no local skills/ of its own."""
+    _git_init(tmp_path)
+    make_skill(tmp_path, "root-skill", description="Lives at the repo root.")
+
+    app_dir = tmp_path / "mas-lab" / "apps" / "sre-triage"
+    app_dir.mkdir(parents=True)
+
+    discovery = Discovery(manifest_skills=["root-skill"], base_dir=app_dir)
+    registry = discovery.discover()
+
+    rec = registry.get("root-skill")
+    assert rec is not None
+    assert rec.path == (tmp_path / "skills" / "root-skill" / "SKILL.md").resolve()
+
+
+def test_local_skills_dir_still_shadows_root(tmp_path: Path):
+    """An app-local skills/<name> still wins over the same name at git root
+    (first-found-wins is unaffected by including the root in the walk)."""
+    _git_init(tmp_path)
+    make_skill(tmp_path, "dup", description="Root version.")
+
+    app_dir = tmp_path / "app"
+    make_skill(app_dir, "dup", description="Local version.")
+
+    discovery = Discovery(manifest_skills=["dup"], base_dir=app_dir)
+    registry = discovery.discover()
+
+    rec = registry.get("dup")
+    assert rec is not None
+    assert rec.path == (app_dir / "skills" / "dup" / "SKILL.md").resolve()
+
+
+def test_ancestor_walk_depth_limit_can_still_exclude_git_root(tmp_path: Path):
+    """ancestor_walk_depth=0 stops before reaching a git root several levels
+    up, preserving the escape hatch for callers that don't want monorepo
+    sharing."""
+    _git_init(tmp_path)
+    make_skill(tmp_path, "root-skill", description="Lives at the repo root.")
+
+    app_dir = tmp_path / "mas-lab" / "apps" / "sre-triage"
+    app_dir.mkdir(parents=True)
+
+    discovery = Discovery(
+        manifest_skills=["root-skill"], base_dir=app_dir, ancestor_walk_depth=0
+    )
+    registry = discovery.discover()
+
+    assert registry.get("root-skill") is None


### PR DESCRIPTION
## Summary

- `Discovery._walk_ancestors()` broke out of the loop the moment `parent == git_root`, **before** checking that directory's own `skills/` subfolder — so a monorepo root-level `skills/` was never scanned, even though it's exactly where shared skills across apps would live.
- Moves the git-root check to run *after* that directory's `skills/` is added to the search roots, so the walk-up now reaches it. `ancestor_walk_depth` still works as an escape hatch to stop earlier.
- Flips the "Ancestor dirs up to git root (monorepo)" row in `docs/spec-coverage.md` from ❌ to ✅.

## Test plan

- [x] New `library-skills/tests/test_discovery_ancestor_walk.py`: skill only present at a real git root's `skills/` resolves from a nested app dir; a same-named local `skills/<name>` still shadows the root one (first-found-wins preserved); `ancestor_walk_depth=0` still excludes the root as an escape hatch.
- [x] Full `library-skills/tests/` suite: 169 passed, 69 skipped (missing optional `google-adk`/`deepagents` extras), same 9 pre-existing unrelated errors confirmed present with `git stash` (entry-point resolution gap in ad-hoc test env, not caused by this change) — no regressions.