### PR TITLE
feat: add stdin to run_skill_script

### DIFF
--- a/library-skills/skill-sandbox/src/sandbox/runner.py
+++ b/library-skills/skill-sandbox/src/sandbox/runner.py
@@ -56,6 +56,7 @@ def run_script(
     cwd: Path | None = None,
     timeout: int | None = None,
     env_extra: dict[str, str] | None = None,
+    stdin: str = "",
 ) -> ScriptResult:
     """Execute a script in a sandboxed subprocess.
 
@@ -65,6 +66,11 @@ def run_script(
         cwd: Working directory (default: script's parent directory).
         timeout: Execution timeout in seconds (default: 30, max: 120).
         env_extra: Additional environment variables (merged after safe base).
+        stdin: Text to feed to the script's stdin. Always passed through as
+            subprocess.run's `input=`, even when empty — this closes stdin
+            with an immediate EOF rather than leaving it to inherit this
+            process's own stdin, which never produces data or EOF here and
+            would leave any script that reads stdin blocked until timeout.
 
     Returns:
         ScriptResult with exit_code, stdout, stderr, ok fields.
@@ -99,6 +105,7 @@ def run_script(
     try:
         result = subprocess.run(
             cmd,
+            input=stdin,
             capture_output=True,
             text=True,
             timeout=timeout_val,

--- a/library-skills/src/mas/library/skills/plugins/sk_shell.py
+++ b/library-skills/src/mas/library/skills/plugins/sk_shell.py
@@ -81,6 +81,14 @@ class RunSkillScriptPlugin(ToolContract):
                                 "LD_PRELOAD, etc.) are rejected."
                             ),
                         },
+                        "stdin": {
+                            "type": "string",
+                            "description": (
+                                "Text to feed to the script's stdin (optional). Use this "
+                                "for a script documented as reading a reply from stdin — "
+                                "passing text via `args` or `env` never reaches it."
+                            ),
+                        },
                     },
                     "required": ["skill", "script"],
                 },
@@ -106,6 +114,7 @@ class RunSkillScriptPlugin(ToolContract):
             args = require_str_list_arg(arguments, "args")
             env = require_dict_arg(arguments, "env")
             timeout = min(require_number_arg(arguments, "timeout", _DEFAULT_TIMEOUT), _MAX_TIMEOUT)
+            stdin = require_str_arg(arguments, "stdin")
         except TypeError as exc:
             return {"error": str(exc)}
         return self._run_script(
@@ -114,6 +123,7 @@ class RunSkillScriptPlugin(ToolContract):
             args=args,
             timeout=timeout,
             extra_env=sanitize_extra_env(env),
+            stdin=stdin,
             registry=registry,
             backend_plugin=backend_plugin,
         )
@@ -130,6 +140,7 @@ class RunSkillScriptPlugin(ToolContract):
         extra_env: dict[str, str],
         registry: SkillRegistry | None,
         backend_plugin: Any | None,
+        stdin: str = "",
     ) -> dict[str, Any]:
         if not skill:
             return {"error": "skill is required"}
@@ -199,6 +210,7 @@ class RunSkillScriptPlugin(ToolContract):
                 cwd=record.base_dir,
                 timeout=timeout,
                 env_extra=extra_env,
+                stdin=stdin,
             )
         except Exception as exc:
             return {"error": f"Cannot run script {script!r} for skill {skill!r}: {exc}"}


### PR DESCRIPTION
## Problem

`run_skill_script` has no way to feed stdin to the scripts it runs. `sandbox.run_script()`'s `subprocess.run(...)` call never passes a `stdin=`/`input=` argument, so a launched script inherits this process's own stdin — which never produces data or an EOF here. Any script that reads stdin (e.g. a `--file -` / "or on stdin" convention) blocks until timeout.

Found via a real failure: an agent calling `concord.py record reply --file -` to record an agent's reply. Every call timed out (`exit_code: 124`). 

## Fix

- `sandbox.run_script()` gains `stdin: str = ""`, always passed as `subprocess.run`'s `input=` — immediate EOF when empty, real content when given. Either way, nothing blocks waiting for stdin that will never arrive.
- `run_skill_script`'s tool schema gains a matching optional `"stdin"` parameter, threaded through to the call above.
