### PR TITLE
feat(runtime): add user communication contracts for agent HITL

### DIFF
--- a/ctl/src/mas/ctl/cli/commands/chat.py
+++ b/ctl/src/mas/ctl/cli/commands/chat.py
@@ -8,19 +8,20 @@ import sys
 from pathlib import Path
 
 import click
-
-from mas.ctl.session.bootstrap import InstantiationOptions, instantiate_runtime
+from mas.ctl.cli.help_text import CHAT_EPILOG
 from mas.ctl.cli.obs_flags import observability_options, resolve_observability_config
 from mas.ctl.cli.trace_flags import trace_options
+from mas.ctl.session.bootstrap import InstantiationOptions, instantiate_runtime
 from mas.ctl.session.controller import (
     ConversationConfig,
     SessionController,
     close_observability,
     run_session_loop,
 )
+from mas.ctl.session.display_user_io_contract import ConversationDisplayUserIOContract
 from mas.ctl.session.hitl_config import resolve_hitl_from_manifest
+from mas.ctl.session.interactive_hitl_contract import InteractiveHitlContract
 from mas.ctl.session.observability import setup_observability
-from mas.ctl.cli.help_text import CHAT_EPILOG
 from mas.ctl.session.protocol_hints import emit_session_protocol_hints
 from mas.ctl.ui.stdout import StdoutConversationDisplay
 
@@ -136,9 +137,9 @@ def chat_cmd(
     Use --help for session commands (/quit, /steer), HITL, and examples.
     """
     from mas.ctl.env import load_dotenv
+    from mas.ctl.runtime_cli import load_merged_agent_manifest
     from mas.ctl.session.infra_resolve import resolve_session_infra
     from mas.ctl.workspace.config import UserConfig, WorkspaceConfig
-    from mas.ctl.runtime_cli import load_merged_agent_manifest
 
     verbose = int(ctx.obj.get("verbose", 0) if ctx.obj else 0)
 
@@ -190,12 +191,29 @@ def chat_cmd(
             session_interactive=interactive,
         )
 
+        # Built here (not later, where it used to live) so it can also back
+        # user_io_contract below -- same instance is reused for the
+        # SessionController further down.
+        display = StdoutConversationDisplay(
+            out=click.get_text_stream("stdout"),
+            verbose=verbose,
+            show_labels=not interactive,
+            user_prompt_echoed=interactive,
+        )
+
+        # Agent-initiated HITL (request_human_input)/inform_user() otherwise
+        # default to a registry-based contract nothing in an interactive CLI
+        # session ever resolves or reads. Give interactive sessions a real
+        # resolver/display instead; non-interactive runs keep the default
+        # (registry) contracts -- unset here means RegistryHitlContract/
+        # RegistryUserIOContract, matching batch/scripted behavior unchanged.
+        hitl_contract = InteractiveHitlContract() if interactive else None
+        user_io_contract = ConversationDisplayUserIOContract(display) if interactive else None
+
         def _opt_file(path: str | None) -> Path | None:
             if not path:
                 return None
-            return resolve_overlay_path(
-                path, orig_cwd=session.original_cwd, manifest_dir=session.manifest_dir
-            )
+            return resolve_overlay_path(path, orig_cwd=session.original_cwd, manifest_dir=session.manifest_dir)
 
         def _opt_dir(path: str | None) -> Path | None:
             if not path:
@@ -219,6 +237,8 @@ def chat_cmd(
                     cache_read_override=cache_read,
                     cache_write_override=cache_write,
                     stream_override=stream,
+                    hitl_contract=hitl_contract,
+                    user_io_contract=user_io_contract,
                     agent_manifest=agent_data,
                     manifest_dir=session.manifest_dir if manifest else None,
                     resolved_infra=resolve_session_infra(
@@ -263,29 +283,23 @@ def chat_cmd(
             manifest=agent_data,
         )
 
-        display = StdoutConversationDisplay(
-            out=click.get_text_stream("stdout"),
-            verbose=verbose,
-            show_labels=not interactive,
-            user_prompt_echoed=interactive,
-        )
-        
         # Extract agent name from manifest metadata; use "n/a" if not available
         import os
+
         agent_name = agent_data.get("metadata", {}).get("name", "n/a") if agent_data else "n/a"
         if agent_name == "agent" and not manifest:
             # CLI-only run without explicit manifest: show "n/a" instead of generic "agent"
             agent_name = "n/a"
-        
+
         # Get LLM model name (in order of precedence: CLI --model > env vars > default)
         llm_name = (
             model
-            or os.getenv("LLM_MODEL") 
-            or os.getenv("OPENAI_MODEL") 
+            or os.getenv("LLM_MODEL")
+            or os.getenv("OPENAI_MODEL")
             or os.getenv("MAS_LLM_MODEL")
             or "gpt-4o-mini"  # Fallback default
         )
-        
+
         controller = SessionController(
             instance=instance,
             display=display,

--- a/ctl/src/mas/ctl/session/display_user_io_contract.py
+++ b/ctl/src/mas/ctl/session/display_user_io_contract.py
@@ -1,0 +1,37 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""ConversationDisplayUserIOContract — routes agent-initiated inform_user() progress
+updates through the CLI's own ConversationDisplay, instead of the default
+RegistryUserIOContract (a fire-and-forget registry entry nothing in ctl ever reads).
+
+Without this, `inform_user()` progress messages were invisible in `mas-ctl chat` --
+silently registered and never displayed."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mas.ctl.ui.display import ConversationDisplay
+
+
+class ConversationDisplayUserIOContract:
+    """UserIOContract that renders progress updates via ConversationDisplay.on_system()."""
+
+    def __init__(self, display: ConversationDisplay) -> None:
+        self._display = display
+
+    def send_progress_update(
+        self,
+        *,
+        message: str,
+        session_id: str,
+        agent_id: str,
+        correlation_id: int,
+        requesting_user_id: str,
+        involved_agents: list[str],
+        metadata: dict[str, Any],
+    ) -> None:
+        self._display.on_system(f"[{agent_id}] {message}")
+
+
+__all__ = ["ConversationDisplayUserIOContract"]

--- a/ctl/src/mas/ctl/session/interactive_hitl_contract.py
+++ b/ctl/src/mas/ctl/session/interactive_hitl_contract.py
@@ -1,0 +1,66 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""InteractiveHitlContract — resolves agent-initiated request_human_input() calls by
+prompting the operator directly at the terminal, mirroring OperatorConsole's stdin-prompt
+pattern for the older, separate governance-triggered HITL (see hitl_prompt.py).
+
+Without this, `mas-ctl chat -i` had no resolver for request_human_input() at all: the
+default RegistryHitlContract would register the request and block forever, since nothing
+in an interactive CLI session ever calls HitlResolverRegistry.resolve()."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable, TextIO
+
+
+def _match_choice(raw: str, choices: list[str]) -> str:
+    if not choices or raw in choices:
+        return raw
+    matched = next((choice for choice in choices if choice.lower() == raw.lower()), None)
+    return matched if matched is not None else raw
+
+
+class InteractiveHitlContract:
+    """HITLContract that asks the operator directly at the terminal.
+
+    `timeout` is accepted (per the HITLContract protocol) but ignored -- a
+    synchronous stdin prompt has no meaningful way to time out; the operator
+    is expected to answer.
+    """
+
+    def __init__(
+        self,
+        *,
+        read_line: Callable[[str], str] | None = None,
+        out: TextIO | None = None,
+    ) -> None:
+        self._read_line = read_line or input
+        self._out = out or sys.stderr
+
+    def request_approval(
+        self,
+        *,
+        question: str,
+        session_id: str,
+        requesting_user_id: str,
+        agent_id: str,
+        correlation_id: int,
+        question_type: str,
+        choices: list[str],
+        context_data: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        self._out.write(f"\n── {agent_id} needs your input ──\n{question}\n")
+        if context_data:
+            self._out.write(f"Context: {context_data}\n")
+        if choices:
+            self._out.write(f"Choices: {', '.join(choices)}\n")
+        self._out.flush()
+
+        prompt = "Your response: " if not choices else f"Your response ({'/'.join(choices)}): "
+        choice = _match_choice((self._read_line(prompt) or "").strip(), choices)
+        return {"choice": choice, "steering": ""}
+
+
+__all__ = ["InteractiveHitlContract"]

--- a/ctl/tests/test_display_user_io_contract.py
+++ b/ctl/tests/test_display_user_io_contract.py
@@ -1,0 +1,35 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""ConversationDisplayUserIOContract routes inform_user() progress updates through
+ConversationDisplay.on_system(), instead of the default registry fallback nothing in
+ctl ever reads."""
+
+from __future__ import annotations
+
+from mas.ctl.session.display_user_io_contract import ConversationDisplayUserIOContract
+
+
+class _RecordingDisplay:
+    def __init__(self) -> None:
+        self.system_messages: list[str] = []
+
+    def on_system(self, message: str) -> None:
+        self.system_messages.append(message)
+
+
+def test_send_progress_update_renders_via_on_system() -> None:
+    display = _RecordingDisplay()
+    contract = ConversationDisplayUserIOContract(display)
+
+    result = contract.send_progress_update(
+        message="working on it",
+        session_id="sess-1",
+        agent_id="finance-agent",
+        correlation_id=1,
+        requesting_user_id="jordan",
+        involved_agents=["research-agent"],
+        metadata={"step": 1},
+    )
+
+    assert result is None
+    assert display.system_messages == ["[finance-agent] working on it"]

--- a/ctl/tests/test_interactive_hitl_contract.py
+++ b/ctl/tests/test_interactive_hitl_contract.py
@@ -1,0 +1,85 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""InteractiveHitlContract resolves via a simulated stdin answer instead of blocking
+on a registry nothing in an interactive CLI session ever reads."""
+
+from __future__ import annotations
+
+import io
+
+from mas.ctl.session.interactive_hitl_contract import InteractiveHitlContract
+
+
+def test_prompts_and_returns_free_text_answer() -> None:
+    out = io.StringIO()
+    contract = InteractiveHitlContract(read_line=lambda _prompt: "go ahead", out=out)
+
+    result = contract.request_approval(
+        question="Should I proceed?",
+        session_id="sess-1",
+        requesting_user_id="jordan",
+        agent_id="agent-a",
+        correlation_id=1,
+        question_type="FREE_TEXT",
+        choices=[],
+        context_data={},
+    )
+
+    assert result == {"choice": "go ahead", "steering": ""}
+    assert "agent-a needs your input" in out.getvalue()
+    assert "Should I proceed?" in out.getvalue()
+
+
+def test_matches_choice_case_insensitively() -> None:
+    contract = InteractiveHitlContract(read_line=lambda _prompt: "APPROVE", out=io.StringIO())
+
+    result = contract.request_approval(
+        question="Approve?",
+        session_id="sess-2",
+        requesting_user_id="jordan",
+        agent_id="agent-a",
+        correlation_id=1,
+        question_type="CONFIRM",
+        choices=["approve", "reject"],
+        context_data={},
+    )
+
+    assert result["choice"] == "approve"
+
+
+def test_passes_through_unrecognized_choice_as_free_text() -> None:
+    contract = InteractiveHitlContract(read_line=lambda _prompt: "maybe later", out=io.StringIO())
+
+    result = contract.request_approval(
+        question="Approve?",
+        session_id="sess-3",
+        requesting_user_id="jordan",
+        agent_id="agent-a",
+        correlation_id=1,
+        question_type="CONFIRM",
+        choices=["approve", "reject"],
+        context_data={},
+    )
+
+    assert result["choice"] == "maybe later"
+
+
+def test_displays_context_and_choices() -> None:
+    out = io.StringIO()
+    contract = InteractiveHitlContract(read_line=lambda _prompt: "approve", out=out)
+
+    contract.request_approval(
+        question="Approve?",
+        session_id="sess-4",
+        requesting_user_id="jordan",
+        agent_id="agent-a",
+        correlation_id=1,
+        question_type="CONFIRM",
+        choices=["approve", "reject"],
+        context_data={"amount": 42},
+        timeout=5.0,
+    )
+
+    rendered = out.getvalue()
+    assert "Context: {'amount': 42}" in rendered
+    assert "Choices: approve, reject" in rendered

--- a/runtime/src/mas/runtime/contracts/user_communication_contract.py
+++ b/runtime/src/mas/runtime/contracts/user_communication_contract.py
@@ -1,0 +1,182 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""HITLContract / UserIOContract — the seam between an agent's request_human_input()/
+inform_user() calls and whatever surfaces them to a real human (a CLI prompt, a chat
+UI card, an admin console, ...) and, for HITL, resumes the agent with the answer.
+
+Mirrors HitlResponder (mas.runtime.boundary.hitl.responders) -- a plain Protocol, not
+the deeper CapabilityContract/ContractRegistry taxonomy used for tool/memory/budget-style
+internal capabilities. This is a user-facing interaction seam, not an internal resource
+boundary.
+
+Consumed by _SystemToolHitlWrapper / _SystemToolUserUpdateWrapper
+(mas.runtime.engine.manifest_tool_provider), which construct a Registry*Contract by
+default when no other implementation is supplied -- so every existing caller keeps its
+current (registry-based) behavior unless it deliberately opts into something else.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Protocol
+
+from mas.runtime.boundary.hitl.registry import HitlResolverRegistry
+
+
+def _resolve_registry(registry: HitlResolverRegistry | None) -> HitlResolverRegistry:
+    if registry is not None:
+        return registry
+    from mas.runtime.boundary.hitl.registry import get_hitl_resolver_registry
+
+    return get_hitl_resolver_registry()
+
+
+class HITLContract(Protocol):
+    """Ask a human a question and get their answer back, resuming the agent."""
+
+    def request_approval(
+        self,
+        *,
+        question: str,
+        session_id: str,
+        requesting_user_id: str,
+        agent_id: str,
+        correlation_id: int,
+        question_type: str,
+        choices: list[str],
+        context_data: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Return at least {"choice": <str>}; may also include "steering" (free text).
+
+        `timeout` (seconds) is the caller's requested wait limit -- None means
+        wait indefinitely. Implementations that can't meaningfully time out
+        (e.g. a synchronous stdin prompt) may ignore it; a blocking
+        implementation should raise TimeoutError if it elapses.
+        """
+        ...
+
+
+class UserIOContract(Protocol):
+    """Send a non-blocking progress update to whoever is watching the session."""
+
+    def send_progress_update(
+        self,
+        *,
+        message: str,
+        session_id: str,
+        agent_id: str,
+        correlation_id: int,
+        requesting_user_id: str,
+        involved_agents: list[str],
+        metadata: dict[str, Any],
+    ) -> Any:
+        """Return value is an opaque receipt -- callers should not depend on its shape."""
+        ...
+
+
+class RegistryHitlContract:
+    """The default HITLContract: register in HitlResolverRegistry and block until an
+    external resolver (chat integration, admin console, ...) calls registry.resolve(), or until
+    `timeout` elapses.
+
+    This is exactly the registry-register-and-block behavior _SystemToolHitlWrapper used
+    to run inline as its "no contract supplied" fallback -- moved here so that behavior is
+    the default *implementation* of a real contract, not a hidden special case.
+    """
+
+    def __init__(self, registry: HitlResolverRegistry | None = None) -> None:
+        self._registry = _resolve_registry(registry)
+
+    def request_approval(
+        self,
+        *,
+        question: str,
+        session_id: str,
+        requesting_user_id: str,
+        agent_id: str,
+        correlation_id: int,
+        question_type: str,
+        choices: list[str],
+        context_data: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        from mas.runtime.schema.hitl import HitlQuestionType
+
+        resolution_event = threading.Event()
+        resolution_result: dict[str, str | None] = {"choice": None, "steering": None}
+
+        def callback(choice: str, steering: str) -> dict[str, str]:
+            """Callback invoked by external resolver (chat integration, admin console, ...)."""
+            resolution_result["choice"] = choice
+            resolution_result["steering"] = steering
+            resolution_event.set()
+            return {"status": "resolved", "choice": choice}
+
+        self._registry.register(
+            session_id=session_id,
+            agent_id=agent_id,
+            correlation_id=correlation_id,
+            question=question,
+            question_type=HitlQuestionType(question_type),
+            choices=choices,
+            context_data=context_data,
+            resolver_callback=callback,
+        )
+
+        did_resolve = resolution_event.wait(timeout=timeout)
+
+        if not did_resolve:
+            try:
+                self._registry.resolve(session_id, agent_id, correlation_id, choice="__timeout__", steering="timeout")
+            except KeyError:
+                pass  # Already resolved or cleaned up
+            raise TimeoutError(
+                f"HITL request timed out after {timeout}s "
+                f"(session={session_id}, agent={agent_id}, correlation_id={correlation_id}): {question}"
+            )
+
+        return {
+            "choice": resolution_result["choice"],
+            "steering": resolution_result["steering"] or "",
+            "question": question,
+            "resolved": True,
+        }
+
+
+class RegistryUserIOContract:
+    """The default UserIOContract: register a fire-and-forget entry in
+    HitlResolverRegistry's user-update channel (e.g. polled by an external integration via
+    get_pending_user_updates_for_session())."""
+
+    def __init__(self, registry: HitlResolverRegistry | None = None) -> None:
+        self._registry = _resolve_registry(registry)
+
+    def send_progress_update(
+        self,
+        *,
+        message: str,
+        session_id: str,
+        agent_id: str,
+        correlation_id: int,
+        requesting_user_id: str,
+        involved_agents: list[str],
+        metadata: dict[str, Any],
+    ) -> None:
+        self._registry.register_user_update(
+            session_id=session_id,
+            agent_id=agent_id,
+            correlation_id=correlation_id,
+            message=message,
+            user_name=requesting_user_id,
+            involved_agents=involved_agents,
+            metadata=metadata,
+        )
+
+
+__all__ = [
+    "HITLContract",
+    "UserIOContract",
+    "RegistryHitlContract",
+    "RegistryUserIOContract",
+]

--- a/runtime/src/mas/runtime/engine/manifest_tool_provider.py
+++ b/runtime/src/mas/runtime/engine/manifest_tool_provider.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-
 from mas.runtime.contracts.tool_contract import ToolContract
+from mas.runtime.contracts.user_communication_contract import HITLContract, UserIOContract
 from mas.runtime.manifest.schema import ToolDocument
 
 logger = logging.getLogger(__name__)
@@ -86,8 +86,7 @@ def _resolve_under_roots(
         except ValueError:
             continue
     raise ManifestToolLoadError(
-        f"path escapes allowed roots: {ref!r} from {ref_base} "
-        f"(roots: {', '.join(str(r) for r in containment_roots)})"
+        f"path escapes allowed roots: {ref!r} from {ref_base} (roots: {', '.join(str(r) for r in containment_roots)})"
     )
 
 
@@ -135,12 +134,8 @@ class ManifestToolProvider:
                         yaml_contract = self._tool_contracts.get(str(spec.get("name")))
                         if yaml_contract:
                             merged["name"] = yaml_contract.get("name", merged.get("name"))
-                            merged["description"] = yaml_contract.get(
-                                "description", merged.get("description", "")
-                            )
-                            merged["parameters"] = yaml_contract.get(
-                                "parameters", merged.get("parameters", {})
-                            )
+                            merged["description"] = yaml_contract.get("description", merged.get("description", ""))
+                            merged["parameters"] = yaml_contract.get("parameters", merged.get("parameters", {}))
                         result.append(merged)
                     continue
             except NotImplementedError:
@@ -158,9 +153,7 @@ class ManifestToolProvider:
                     legacy.update(yaml_contract)
                 result.append(legacy)
             except Exception as exc:
-                raise ManifestToolLoadError(
-                    f"Tool instance {instance!r} failed to describe itself: {exc}"
-                ) from exc
+                raise ManifestToolLoadError(f"Tool instance {instance!r} failed to describe itself: {exc}") from exc
         return result
 
     def list_openai_tools(self, *, ctx: Any = None) -> list[dict[str, Any]]:
@@ -175,8 +168,7 @@ class ManifestToolProvider:
                     "function": {
                         "name": name,
                         "description": str(spec.get("description") or f"Invoke tool {name}."),
-                        "parameters": spec.get("parameters")
-                        or {"type": "object", "properties": {}},
+                        "parameters": spec.get("parameters") or {"type": "object", "properties": {}},
                     },
                 }
             )
@@ -208,9 +200,7 @@ class ManifestToolProvider:
             if not owns and not legacy_match:
                 continue
             try:
-                result = instance.on_execute_tool(
-                    tool_name, arguments, ctx=ctx, user=user
-                )
+                result = instance.on_execute_tool(tool_name, arguments, ctx=ctx, user=user)
                 if result is not None:
                     return result
                 if owns:
@@ -239,9 +229,7 @@ class ManifestToolProvider:
         if manifest_contract is not None:
             name = str(manifest_contract["name"])
             if name in self._tool_contracts:
-                raise ManifestToolLoadError(
-                    f"duplicate manifest tool name {name!r}"
-                )
+                raise ManifestToolLoadError(f"duplicate manifest tool name {name!r}")
             self._tool_contracts[name] = manifest_contract
         self._tool_instances.append(instance)
 
@@ -252,8 +240,8 @@ def build_manifest_tool_provider(
     *,
     app_root: Path | None = None,
     include_system_tools: bool = True,
-    hitl_contract: Any | None = None,
-    user_io_contract: Any | None = None,
+    hitl_contract: HITLContract | None = None,
+    user_io_contract: UserIOContract | None = None,
     **containment_kw: Any,
 ) -> ManifestToolProvider:
     """Build a provider from ``spec.tools`` (refs or inline module_path entries)."""
@@ -292,14 +280,10 @@ def build_manifest_tool_provider(
                 raw.get("name"),
             )
             continue
-        tool_def, mdir, manifest_contract = _normalize_tool_entry(
-            raw, manifest_dir, index, containment_roots=roots
-        )
+        tool_def, mdir, manifest_contract = _normalize_tool_entry(raw, manifest_dir, index, containment_roots=roots)
         module_path = tool_def.get("module_path")
         if not module_path:
-            raise ManifestToolLoadError(
-                f"spec.tools[{index}]: missing module_path after resolving entry {raw!r}"
-            )
+            raise ManifestToolLoadError(f"spec.tools[{index}]: missing module_path after resolving entry {raw!r}")
         class_name = tool_def.get("class_name")
         params = dict(tool_def.get("params") or {})
         instance = _load_tool_instance(
@@ -319,11 +303,7 @@ def _hitl_system_tool_params(tools_spec: list[Any]) -> dict[str, Any]:
     the HITL wrapper's timeout/auto_resolve_decision (a call's own ``timeout``
     argument still wins over this)."""
     for raw in tools_spec or []:
-        if (
-            isinstance(raw, dict)
-            and raw.get("kind") == "system"
-            and raw.get("name") == "request_human_input"
-        ):
+        if isinstance(raw, dict) and raw.get("kind") == "system" and raw.get("name") == "request_human_input":
             return dict(raw.get("params") or {})
     return {}
 
@@ -331,8 +311,8 @@ def _hitl_system_tool_params(tools_spec: list[Any]) -> dict[str, Any]:
 def _inject_system_tools(
     provider: ManifestToolProvider,
     *,
-    hitl_contract: Any | None = None,
-    user_io_contract: Any | None = None,
+    hitl_contract: HITLContract | None = None,
+    user_io_contract: UserIOContract | None = None,
     hitl_default_timeout_seconds: float | None = None,
     hitl_auto_resolve_decision: str | None = None,
 ) -> None:
@@ -426,11 +406,12 @@ class _SystemToolHitlWrapper(_SystemToolWrapperBase):
     Catches RequestHitlSignal and resolves it, in priority order:
     1. Batch/CLI/bench mode (MAS_HITL_AUTO_RESOLVE set): auto-resolve immediately,
        no external resolver is listening.
-    2. HITLContract, if one was supplied (e.g. an admin-approval abstraction).
-    3. Fallback: register in the shared HitlResolverRegistry and BLOCK until an
-       external resolver (e.g. the Webex bot) provides the user's response.
+    2. hitl_contract.request_approval() -- defaults to RegistryHitlContract
+       (register in the shared HitlResolverRegistry and BLOCK until an external
+       resolver, e.g. an external integration or an interactive CLI prompt, provides the
+       user's response) unless a different HITLContract was supplied.
 
-    Timeout handling (fallback path only):
+    Timeout handling (RegistryHitlContract path):
     - The call's own `timeout` argument wins; otherwise `default_timeout_seconds`
       (the manifest-configured default, if any) applies; with neither set, the
       wait has no timeout at all.
@@ -441,20 +422,22 @@ class _SystemToolHitlWrapper(_SystemToolWrapperBase):
     def __init__(
         self,
         tool_instance: Any,
-        hitl_contract: Any | None = None,
+        hitl_contract: HITLContract | None = None,
         *,
         default_timeout_seconds: float | None = None,
         auto_resolve_decision: str | None = None,
     ) -> None:
         super().__init__(tool_instance)
-        self._hitl_contract = hitl_contract
+        if hitl_contract is None:
+            from mas.runtime.contracts.user_communication_contract import RegistryHitlContract
+
+            hitl_contract = RegistryHitlContract()
+        self._hitl_contract: HITLContract = hitl_contract
         self._default_timeout_seconds = default_timeout_seconds
         self._auto_resolve_decision = (
-            auto_resolve_decision
-            or os.environ.get("MAS_HITL_AUTO_RESOLVE_DECISION")
-            or "approve"
+            auto_resolve_decision or os.environ.get("MAS_HITL_AUTO_RESOLVE_DECISION") or "approve"
         )
-    
+
     def on_execute_tool(
         self,
         tool_name: str,
@@ -464,19 +447,19 @@ class _SystemToolHitlWrapper(_SystemToolWrapperBase):
         user: str = "",
     ) -> Any:
         """Execute tool and catch HITL signal.
-        
-        If the tool raises RequestHitlSignal, resolve it via auto-resolve,
-        HITLContract, or the registry-based blocking fallback (in that order).
+
+        If the tool raises RequestHitlSignal, resolve it via auto-resolve or
+        self._hitl_contract.request_approval() (in that order).
         """
         from mas.runtime.system_tools.signal import RequestHitlSignal
-        
+
         try:
             return self._execute_wrapped(tool_name, arguments, ctx=ctx, user=user)
         except RequestHitlSignal as signal:
             session_id, agent_id, correlation_id = self._extract_context(ctx)
 
             # Batch/CLI auto-hitl mode (e.g. `mas-ctl run-mas --auto-hitl`, the
-            # default): there is no external resolver (Webex bot, operator
+            # default): there is no external resolver (integration adapter, operator
             # console, etc.) listening on the registry, so blocking for the
             # full timeout would always fail. Resolve immediately with a
             # default choice instead, mirroring the existing AutoApproveResponder
@@ -491,117 +474,48 @@ class _SystemToolHitlWrapper(_SystemToolWrapperBase):
                 )
                 return {"choice": self._auto_resolve_decision, "steering": ""}
 
-            # Route through HITLContract if available (e.g. an admin-approval
-            # abstraction distinct from the raw Webex-bot registry channel).
-            if self._hitl_contract is not None:
-                try:
-                    result = self._hitl_contract.request_approval(
-                        question=signal.question,
-                        session_id=session_id,
-                        requesting_user_id=user,
-                        agent_id=agent_id,
-                        correlation_id=correlation_id,
-                        question_type=signal.question_type.value,
-                        choices=signal.choices,
-                        context_data=signal.context_data,
-                    )
-                    logger.info(
-                        "Agent %s HITL resolved via HITLContract: approver chose '%s'",
-                        agent_id,
-                        result.get("choice"),
-                    )
-                    return result
-                except Exception as exc:
-                    logger.warning(
-                        "HITLContract approval failed for agent=%s session=%s: %s. "
-                        "Falling back to registry.",
-                        agent_id,
-                        session_id,
-                        exc,
-                    )
-
-            # Fallback: registry-based blocking resolution (production path —
-            # e.g. the Webex bot resolves via resolve_agent_hitl()).
-            resolution_event = threading.Event()
-            resolution_result = {"choice": None, "steering": None}
-            
-            def callback(choice: str, steering: str) -> dict[str, str]:
-                """Callback invoked by external resolver (Webex bot)."""
-                resolution_result["choice"] = choice
-                resolution_result["steering"] = steering
-                resolution_event.set()  # Unblock waiting thread
-                return {"status": "resolved", "choice": choice}
-            
-            from mas.runtime.boundary.hitl.registry import get_hitl_resolver_registry
-            
-            registry = get_hitl_resolver_registry()
-            registry.register(
-                session_id=session_id,
-                agent_id=agent_id,
-                correlation_id=correlation_id,
-                question=signal.question,
-                question_type=signal.question_type,
-                choices=signal.choices,
-                context_data=signal.context_data,
-                resolver_callback=callback,  # ← This unblocks the agent
-            )
-            
-            timeout_seconds = (
-                signal.timeout if signal.timeout is not None else self._default_timeout_seconds
-            )
+            timeout_seconds = signal.timeout if signal.timeout is not None else self._default_timeout_seconds
             logger.info(
-                f"Agent {agent_id} blocked waiting for HITL resolution "
+                f"Agent {agent_id} awaiting HITL resolution "
                 f"(timeout={timeout_seconds if timeout_seconds is not None else 'none'}s): "
                 f"{signal.question}"
             )
-            did_resolve = resolution_event.wait(timeout=timeout_seconds)
-
-            if not did_resolve:
-                # Timeout - no response from user. Clean up registry entry.
-                try:
-                    registry.resolve(
-                        session_id, agent_id, correlation_id,
-                        choice="__timeout__", steering="timeout"
-                    )
-                except KeyError:
-                    pass  # Already resolved or cleaned up
-                
-                raise TimeoutError(
-                    f"HITL request timed out after {timeout_seconds}s "
-                    f"(session={session_id}, agent={agent_id}, "
-                    f"correlation_id={correlation_id}): {signal.question}"
-                )
-            
-            user_choice = resolution_result["choice"]
-            user_steering = resolution_result["steering"] or ""
-            
-            logger.info(
-                f"Agent {agent_id} HITL resolved: user chose '{user_choice}'"
+            result = self._hitl_contract.request_approval(
+                question=signal.question,
+                session_id=session_id,
+                requesting_user_id=user,
+                agent_id=agent_id,
+                correlation_id=correlation_id,
+                question_type=signal.question_type.value,
+                choices=signal.choices,
+                context_data=signal.context_data,
+                timeout=timeout_seconds,
             )
-            
-            return {
-                "choice": user_choice,
-                "steering": user_steering,
-                "question": signal.question,
-                "resolved": True,
-            }
+            logger.info("Agent %s HITL resolved: user chose '%s'", agent_id, result.get("choice"))
+            return result
 
 
 class _SystemToolUserUpdateWrapper(_SystemToolWrapperBase):
     """Wrapper for system tools that emit non-blocking user status updates.
 
-    Catches InformUserSignal and routes it, in priority order:
-    1. UserIOContract, if one was supplied.
-    2. Fallback: register in the shared HitlResolverRegistry's user-update
-       channel, polled by external systems (e.g. the Webex bot).
+    Catches InformUserSignal and routes it through
+    user_io_contract.send_progress_update() -- defaults to RegistryUserIOContract
+    (register in the shared HitlResolverRegistry's user-update channel, e.g.
+    polled by an external integration) unless a different UserIOContract was supplied.
 
     Unlike `_SystemToolHitlWrapper`, this never blocks: the tool call returns
-    immediately regardless of which channel consumes the update.
+    immediately regardless of which implementation consumes the update.
     """
 
-    def __init__(self, tool_instance: Any, user_io_contract: Any | None = None) -> None:
+    def __init__(self, tool_instance: Any, user_io_contract: UserIOContract | None = None) -> None:
         super().__init__(tool_instance)
-        self._user_io_contract = user_io_contract
+        if user_io_contract is None:
+            from mas.runtime.contracts.user_communication_contract import (
+                RegistryUserIOContract,
+            )
+
+            user_io_contract = RegistryUserIOContract()
+        self._user_io_contract: UserIOContract = user_io_contract
 
     def on_execute_tool(
         self,
@@ -619,57 +533,17 @@ class _SystemToolUserUpdateWrapper(_SystemToolWrapperBase):
         except InformUserSignal as signal:
             session_id, agent_id, correlation_id = self._extract_context(ctx)
 
-            # Route through UserIOContract if available.
-            if self._user_io_contract is not None:
-                try:
-                    receipt = self._user_io_contract.send_progress_update(
-                        message=signal.message,
-                        session_id=session_id,
-                        requesting_user_id=signal.user_name or user,
-                        agent_id=agent_id,
-                        involved_agents=signal.involved_agents,
-                        metadata=signal.metadata,
-                    )
-                    logger.info(
-                        "Agent %s sent progress update via UserIOContract for session=%s",
-                        agent_id,
-                        session_id,
-                    )
-                    return {
-                        "status": "sent",
-                        "message": signal.message,
-                        "user_name": signal.user_name or user,
-                        "involved_agents": list(signal.involved_agents),
-                        "metadata": dict(signal.metadata),
-                        "blocking": False,
-                        "receipt": receipt,
-                    }
-                except Exception as exc:
-                    logger.warning(
-                        "UserIOContract progress update failed for agent=%s session=%s: %s. "
-                        "Falling back to registry.",
-                        agent_id,
-                        session_id,
-                        exc,
-                    )
-
-            # Fallback: direct registry registration (e.g. the Webex bot polls
-            # get_pending_user_updates_for_session()).
-            from mas.runtime.boundary.hitl.registry import get_hitl_resolver_registry
-
-            registry = get_hitl_resolver_registry()
-            registry.register_user_update(
+            receipt = self._user_io_contract.send_progress_update(
+                message=signal.message,
                 session_id=session_id,
+                requesting_user_id=signal.user_name or user,
                 agent_id=agent_id,
                 correlation_id=correlation_id,
-                message=signal.message,
-                user_name=signal.user_name or user,
                 involved_agents=signal.involved_agents,
                 metadata=signal.metadata,
             )
-
             logger.info(
-                "Agent %s emitted non-blocking user update (registry fallback) for session=%s: %s",
+                "Agent %s sent progress update for session=%s: %s",
                 agent_id,
                 session_id,
                 signal.message,
@@ -681,6 +555,7 @@ class _SystemToolUserUpdateWrapper(_SystemToolWrapperBase):
                 "involved_agents": list(signal.involved_agents),
                 "metadata": dict(signal.metadata),
                 "blocking": False,
+                "receipt": receipt,
             }
 
 
@@ -722,9 +597,7 @@ def _normalize_tool_entry(
         if catalog_ref_path is not None:
             ref_path = catalog_ref_path
         else:
-            ref_path = _resolve_under_roots(
-                mdir, str(tool_def["ref"]), containment_roots=containment_roots
-            )
+            ref_path = _resolve_under_roots(mdir, str(tool_def["ref"]), containment_roots=containment_roots)
         if not ref_path.is_file():
             raise ManifestToolLoadError(f"spec.tools[{index}]: tool ref not found: {ref_path}")
         try:
@@ -739,9 +612,7 @@ def _normalize_tool_entry(
             raise ManifestToolLoadError(f"spec.tools[{index}]: {exc}") from exc
         impl = (doc.get("spec") or {}).get("impl") or {}
         if not impl.get("module_path"):
-            raise ManifestToolLoadError(
-                f"spec.tools[{index}]: tool {ref_path} missing spec.impl.module_path"
-            )
+            raise ManifestToolLoadError(f"spec.tools[{index}]: tool {ref_path} missing spec.impl.module_path")
         tool_name = tool_contract.name or ref_path.stem.replace(".tool", "")
         manifest_contract = tool_contract.to_contract_dict(tool_name)
         tool_def = {
@@ -757,9 +628,7 @@ def _normalize_tool_entry(
     elif tool_def.get("module_path"):
         pass
     else:
-        raise ManifestToolLoadError(
-            f"spec.tools[{index}]: entry must include ref or module_path: {raw!r}"
-        )
+        raise ManifestToolLoadError(f"spec.tools[{index}]: entry must include ref or module_path: {raw!r}")
 
     return tool_def, mdir, manifest_contract
 
@@ -779,9 +648,7 @@ def _load_tool_instance(
         or "\\" in module_path
     )
     if is_file:
-        resolved = _resolve_under_roots(
-            manifest_dir, module_path, containment_roots=containment_roots
-        )
+        resolved = _resolve_under_roots(manifest_dir, module_path, containment_roots=containment_roots)
         if not resolved.is_file():
             raise ManifestToolLoadError(f"Tool module file not found: {resolved}")
         with _TOOL_MODULE_LOAD_LOCK:
@@ -824,14 +691,11 @@ def _load_tool_instance(
         candidates = _tool_class_candidates(module)
         if not candidates:
             raise ManifestToolLoadError(
-                f"No tool class found in {module_path} "
-                "(class_name required, or define on_collect_tools)."
+                f"No tool class found in {module_path} (class_name required, or define on_collect_tools)."
             )
         if len(candidates) > 1:
             names = ", ".join(c.__name__ for c in candidates)
-            raise ManifestToolLoadError(
-                f"multiple tool classes in {module_path}: {names}; specify class_name"
-            )
+            raise ManifestToolLoadError(f"multiple tool classes in {module_path}: {names}; specify class_name")
         tool_class = candidates[0]
 
     return tool_class(**params)
@@ -896,9 +760,7 @@ def attach_manifest_tools(
     if not tools:
         return None
 
-    provider = build_manifest_tool_provider(
-        tools, manifest_dir, app_root=app_root or manifest_dir, **provider_kw
-    )
+    provider = build_manifest_tool_provider(tools, manifest_dir, app_root=app_root or manifest_dir, **provider_kw)
     leaf = leaf_engine(engine)
     leaf.tool_provider = provider
     if isinstance(leaf, LiveLlmEngine):
@@ -917,6 +779,4 @@ def attach_manifest_tools_to_instance(
     engine = getattr(getattr(instance, "driver", None), "engine", None)
     if engine is None:
         return None
-    return attach_manifest_tools(
-        engine, manifest, manifest_dir, app_root=app_root, **provider_kw
-    )
+    return attach_manifest_tools(engine, manifest, manifest_dir, app_root=app_root, **provider_kw)

--- a/runtime/tests/test_user_communication_contract.py
+++ b/runtime/tests/test_user_communication_contract.py
@@ -1,0 +1,180 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""HITLContract/UserIOContract: the default (registry-backed) implementations behave
+exactly like the old inline fallback did, and a custom contract -- previously a dead
+parameter nobody ever set -- is now actually invoked instead of the registry."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mas.runtime.boundary.hitl.registry import get_hitl_resolver_registry
+from mas.runtime.contracts.user_communication_contract import (
+    RegistryHitlContract,
+    RegistryUserIOContract,
+)
+
+
+@dataclass
+class _FakeCtx:
+    session_id: str
+    agent_id: str = "finance-agent"
+    correlation_id: int = 1
+
+
+@pytest.fixture()
+def empty_tool_tree(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# RegistryHitlContract / RegistryUserIOContract in isolation
+# ---------------------------------------------------------------------------
+
+
+def test_registry_hitl_contract_blocks_until_resolved():
+    contract = RegistryHitlContract()
+    registry = get_hitl_resolver_registry()
+
+    def resolve_soon():
+        for _ in range(50):
+            if registry.has_pending("sess-contract-block", "agent-a"):
+                break
+            time.sleep(0.01)
+        registry.resolve("sess-contract-block", "agent-a", 1, choice="approve", steering="go ahead")
+
+    threading.Thread(target=resolve_soon, daemon=True).start()
+
+    result = contract.request_approval(
+        question="Approve?",
+        session_id="sess-contract-block",
+        requesting_user_id="",
+        agent_id="agent-a",
+        correlation_id=1,
+        question_type="CONFIRM",
+        choices=["approve", "reject"],
+        context_data={},
+    )
+    assert result == {
+        "choice": "approve",
+        "steering": "go ahead",
+        "question": "Approve?",
+        "resolved": True,
+    }
+
+
+def test_registry_hitl_contract_raises_timeout_error():
+    contract = RegistryHitlContract()
+    with pytest.raises(TimeoutError):
+        contract.request_approval(
+            question="Approve?",
+            session_id="sess-contract-timeout",
+            requesting_user_id="",
+            agent_id="agent-a",
+            correlation_id=1,
+            question_type="CONFIRM",
+            choices=["approve", "reject"],
+            context_data={},
+            timeout=0.05,
+        )
+
+
+def test_registry_user_io_contract_registers_update():
+    contract = RegistryUserIOContract()
+    registry = get_hitl_resolver_registry()
+
+    contract.send_progress_update(
+        message="working on it",
+        session_id="sess-userio",
+        agent_id="agent-a",
+        correlation_id=1,
+        requesting_user_id="jordan",
+        involved_agents=["agent-b"],
+        metadata={"step": 1},
+    )
+
+    updates = registry.get_pending_user_updates_for_session("sess-userio")
+    assert any(u.message == "working on it" for entries in updates.values() for u in entries)
+
+
+# ---------------------------------------------------------------------------
+# A custom contract is now actually invoked (previously a dead parameter)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingHitlContract:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def request_approval(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"choice": "custom-approved"}
+
+
+class _RecordingUserIOContract:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def send_progress_update(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return {"delivered": True}
+
+
+def test_custom_hitl_contract_is_used_instead_of_registry(empty_tool_tree: Path):
+    from mas.runtime.engine.manifest_tool_provider import _SystemToolHitlWrapper
+    from mas.runtime.system_tools.request_human_input import RequestHumanInputTool
+
+    contract = _RecordingHitlContract()
+    wrapper = _SystemToolHitlWrapper(RequestHumanInputTool(), hitl_contract=contract)
+    ctx = _FakeCtx(session_id="sess-custom-hitl")
+
+    result = wrapper.on_execute_tool(
+        "request_human_input",
+        {"question": "Approve?", "question_type": "CONFIRM", "choices": ["approve", "reject"]},
+        ctx=ctx,
+    )
+
+    assert result["choice"] == "custom-approved"
+    assert len(contract.calls) == 1
+    assert contract.calls[0]["question"] == "Approve?"
+    # The registry must never have been touched for this call.
+    registry = get_hitl_resolver_registry()
+    assert not registry.has_pending("sess-custom-hitl", "finance-agent")
+
+
+def test_custom_user_io_contract_is_used_instead_of_registry(empty_tool_tree: Path):
+    from mas.runtime.engine.manifest_tool_provider import _SystemToolUserUpdateWrapper
+    from mas.runtime.system_tools.inform_user import InformUserTool
+
+    contract = _RecordingUserIOContract()
+    wrapper = _SystemToolUserUpdateWrapper(InformUserTool(), user_io_contract=contract)
+    ctx = _FakeCtx(session_id="sess-custom-userio")
+
+    result = wrapper.on_execute_tool(
+        "inform_user",
+        {"message": "On it", "user_name": "jordan", "involved_agents": []},
+        ctx=ctx,
+    )
+
+    assert result["receipt"] == {"delivered": True}
+    assert len(contract.calls) == 1
+    assert contract.calls[0]["message"] == "On it"
+    registry = get_hitl_resolver_registry()
+    assert registry.get_pending_user_updates_for_session("sess-custom-userio") == {}
+
+
+def test_default_contract_is_registry_backed(empty_tool_tree: Path):
+    from mas.runtime.engine.manifest_tool_provider import _SystemToolHitlWrapper, _SystemToolUserUpdateWrapper
+    from mas.runtime.system_tools.inform_user import InformUserTool
+    from mas.runtime.system_tools.request_human_input import RequestHumanInputTool
+
+    hitl_wrapper = _SystemToolHitlWrapper(RequestHumanInputTool())
+    assert isinstance(hitl_wrapper._hitl_contract, RegistryHitlContract)
+
+    io_wrapper = _SystemToolUserUpdateWrapper(InformUserTool())
+    assert isinstance(io_wrapper._user_io_contract, RegistryUserIOContract)


### PR DESCRIPTION
- Add explicit HITL and user-communication contracts to the runtime.
- Wire agent-driven human input and informational user messages through the contracts.
- Add controller and runtime tests for synchronous resolution and tool results.
- Dispatch former inline registry/fallback behavior to RegistryHitlContract and RegistryUserIOContract defaults.

Signed-off-by: Jordan Augé <augjorda@cisco.com>
