### PR TITLE
fix(runtime): recover textual tool calls from model responses

### DIFF
--- a/runtime/src/mas/runtime/engine/llm_live.py
+++ b/runtime/src/mas/runtime/engine/llm_live.py
@@ -21,12 +21,13 @@ from mas.runtime.boundary.gov.budget import BudgetTracker, budget_from_manifest
 from mas.runtime.engine.exchange_preview import format_llm_messages, format_tool_invoke
 from mas.runtime.engine.llm_cache import (
     assistant_message_from_cache_content,
+    llm_cache_key,
     load_cache,
     lookup_response,
-    llm_cache_key,
     persist_cache,
 )
 from mas.runtime.engine.llm_http import classify_llm_http_error, resolve_ssl_verify
+from mas.runtime.engine.textual_tool_calls import maybe_recover_textual_tool_calls, repair_merged_arg_keys
 from mas.runtime.engine.tool_dispatch import execute_engine_tool
 from mas.runtime.engine.tools import openai_tools
 from mas.runtime.schema.egress import InvokeEngineIo
@@ -64,9 +65,7 @@ class LiveLlmEngine:
     _cache: dict[str, Any] = field(default_factory=dict, init=False)
     _pending_tool: str = field(default="", init=False)
     _pending_tool_args: dict[str, Any] = field(default_factory=dict, init=False)
-    _pending_tools_by_cid: dict[int, tuple[str, dict[str, Any]]] = field(
-        default_factory=dict, init=False
-    )
+    _pending_tools_by_cid: dict[int, tuple[str, dict[str, Any]]] = field(default_factory=dict, init=False)
     _budget: BudgetTracker = field(default_factory=BudgetTracker, init=False)
     _model_access: Any | None = field(default=None, init=False)
 
@@ -75,9 +74,7 @@ class LiveLlmEngine:
         self._pending_tool = name
         self._pending_tool_args = dict(arguments or {})
 
-    def set_tool_for_correlation(
-        self, correlation_id: int, name: str, arguments: dict[str, Any] | None = None
-    ) -> None:
+    def set_tool_for_correlation(self, correlation_id: int, name: str, arguments: dict[str, Any] | None = None) -> None:
         self._pending_tools_by_cid[correlation_id] = (name, dict(arguments or {}))
 
     def __post_init__(self) -> None:
@@ -214,7 +211,6 @@ class LiveLlmEngine:
         tools = llm_request_tools(messages, tools=tool_defs or None)
         answering_from_tools = has_tool_results(messages)
 
-        cache_key = llm_cache_key(self.model, messages, tool_defs or None)
         if self._cache_reads_enabled():
             content, cached_usage, _source = lookup_response(
                 self._cache,
@@ -291,6 +287,7 @@ class LiveLlmEngine:
         usage: dict[str, Any],
         finish_reason: str,
     ) -> EngineIoReturn:
+        message = maybe_recover_textual_tool_calls(message, tool_defs)
         tool_calls = message.get("tool_calls") or []
         if self._cache_writes_enabled():
             self._cache_message(messages, tool_defs, message, usage)
@@ -304,6 +301,8 @@ class LiveLlmEngine:
                     args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
                 except json.JSONDecodeError:
                     args = {"raw": raw_args}
+                if isinstance(args, dict):
+                    args = repair_merged_arg_keys(args)
                 parsed.append((name, args))
             if len(parsed) > 1 and self.parallel_tool_calls:
                 from mas.runtime.schema.ingress import ToolCallSpec
@@ -312,9 +311,7 @@ class LiveLlmEngine:
                     correlation_id=io.correlation_id,
                     response_kind="MODEL_TEXT",
                     next_step="PARALLEL_TOOL_CALLS",
-                    parallel_tools=tuple(
-                        ToolCallSpec(tool_name=name, tool_arguments=args) for name, args in parsed
-                    ),
+                    parallel_tools=tuple(ToolCallSpec(tool_name=name, tool_arguments=args) for name, args in parsed),
                     text="",
                     usage=usage,
                     finish_reason=finish_reason,

--- a/runtime/src/mas/runtime/engine/textual_tool_calls.py
+++ b/runtime/src/mas/runtime/engine/textual_tool_calls.py
@@ -1,0 +1,203 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Fallback recovery for models that emit tool calls inside message content.
+
+Some local OpenAI-compatible backends return tool calls as plain assistant text
+(`<|tool_call>call:fn(args)<tool_call|>`, bare `name(args)`, multiline JSON, ...)
+instead of the structured ``tool_calls`` field. This module is opt-in recovery
+used by ``LiveLlmEngine`` only when structured tool calls are absent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import yaml
+
+_TEXT_TOOL_CALL_RE = re.compile(
+    r"^\s*call:(?P<name>[A-Za-z0-9_.-]+)\((?P<args>.*)\)\s*$",
+    re.DOTALL,
+)
+_BARE_TOOL_CALL_RE = re.compile(r"^\s*(?:-\s*)?(?P<name>[A-Za-z0-9_.-]+)\((?P<args>.*)\)\s*$")
+_BARE_CALL_HEAD_RE = re.compile(r"(?P<name>[A-Za-z_][A-Za-z0-9_.-]*)\(")
+_TEXT_TOOL_CALL_BLOCK_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
+_CHANNEL_MARKUP_RE = re.compile(r"<\|channel>[^\n<]*\n?(?:<channel\|>)?", re.DOTALL)
+_TEXT_VAR_RE = re.compile(r"^\s*(?:-\s*)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?P<value>.+?)\s*$")
+_MERGED_ARG_KEY_RE = re.compile(
+    r"^(?P<first_key>[A-Za-z_][A-Za-z0-9_]*)=(?P<first_value>.*),(?P<second_key>[A-Za-z_][A-Za-z0-9_]*)$",
+    re.DOTALL,
+)
+
+
+def repair_merged_arg_keys(args: dict[str, Any]) -> dict[str, Any]:
+    """Undo a malformed structured tool-call arguments dict from some local models.
+
+    For array-typed parameters (e.g. run_skill_script's ``args``) a backend may
+    emit valid-but-wrong JSON: ``{"args=[...]" : "runner.py", ...}`` instead of
+    ``{"args": [...], "script": "runner.py", ...}`` -- the array literal ends up
+    as text glued onto the START of the key that should have followed it.
+    ``json.loads`` succeeds (it is syntactically valid JSON), so this must be
+    repaired after parsing, not caught as a decode error.
+    """
+    repaired: dict[str, Any] = {}
+    for key, value in args.items():
+        match = _MERGED_ARG_KEY_RE.match(key)
+        if not match:
+            repaired[key] = value
+            continue
+        try:
+            first_value: Any = json.loads(match.group("first_value"))
+        except json.JSONDecodeError:
+            first_value = match.group("first_value")
+        repaired[match.group("first_key")] = first_value
+        repaired[match.group("second_key")] = value
+    return repaired
+
+
+def strip_channel_markup(text: str | None) -> str:
+    return _CHANNEL_MARKUP_RE.sub("", str(text or "")).strip()
+
+
+def recover_tool_calls_from_content(
+    content: str | None,
+    *,
+    known_tool_names: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Recover structured tool calls from message content, plus the leftover text."""
+    raw = str(content or "")
+    cleaned = strip_channel_markup(raw)
+    blocks = _TEXT_TOOL_CALL_BLOCK_RE.findall(raw)
+    variables = _collect_text_variables(cleaned)
+    tool_calls: list[dict[str, Any]] = []
+
+    for idx, item in enumerate(blocks or ([raw] if cleaned.startswith("call:") else []), start=1):
+        match = _TEXT_TOOL_CALL_RE.match(item.strip())
+        if match:
+            args = _parse_textual_tool_call_args(match.group("args"), variables=variables)
+            tool_calls.append(_as_tool_call(idx, match.group("name"), args))
+
+    if not tool_calls:
+        for line in cleaned.splitlines():
+            match = _BARE_TOOL_CALL_RE.match(line.strip())
+            if match:
+                args = _parse_textual_tool_call_args(match.group("args"), variables=variables)
+                tool_calls.append(_as_tool_call(len(tool_calls) + 1, match.group("name"), args))
+
+    if not tool_calls and known_tool_names:
+        spans: list[tuple[int, int]] = []
+        for name, args_raw, start, end in _find_multiline_bare_calls(cleaned, known_names=known_tool_names):
+            args = _parse_textual_tool_call_args(args_raw, variables=variables)
+            tool_calls.append(_as_tool_call(len(tool_calls) + 1, name, args))
+            spans.append((start, end))
+        for start, end in sorted(spans, reverse=True):
+            cleaned = (cleaned[:start] + cleaned[end:]).strip()
+
+    if blocks:
+        cleaned = _TEXT_TOOL_CALL_BLOCK_RE.sub("", cleaned).strip()
+    if tool_calls and cleaned.startswith("call:"):
+        cleaned = ""
+    return tool_calls, cleaned
+
+
+def maybe_recover_textual_tool_calls(
+    message: dict[str, Any],
+    tool_defs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Apply textual tool-call recovery when the assistant message has no structured calls."""
+    if message.get("tool_calls"):
+        return message
+
+    known_tool_names = {
+        str(fn.get("name"))
+        for t in tool_defs
+        if isinstance(t, dict) and isinstance(fn := t.get("function"), dict) and fn.get("name")
+    }
+    tool_calls, recovered_text = recover_tool_calls_from_content(
+        message.get("content"),
+        known_tool_names=known_tool_names,
+    )
+    # Strip channel markup even when no tool call was recovered -- some backends
+    # emit it on plain answers too, and it must never reach the user.
+    return {**message, "tool_calls": tool_calls, "content": recovered_text}
+
+
+def _parse_textual_tool_call_args(
+    raw: str,
+    *,
+    variables: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    variables = variables or {}
+    stripped = raw.strip()
+    if stripped and "=" not in stripped and ":" not in stripped and stripped in variables:
+        return {"value": variables[stripped]}
+
+    payload = raw.replace('<|"|>', '"').strip()
+    if not payload:
+        return {}
+    for name, value in variables.items():
+        payload = re.sub(rf"\b{re.escape(name)}\b", json.dumps(value), payload)
+    payload = payload.replace("=", ":")
+    payload = re.sub(
+        r"(^|[,{]\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:",
+        lambda m: f'{m.group(1)}"{m.group(2)}": ',
+        payload,
+    )
+    if not payload.startswith("{"):
+        payload = "{" + payload + "}"
+    try:
+        loaded = yaml.safe_load(payload)
+    except Exception:
+        return {"raw": raw}
+    return dict(loaded) if isinstance(loaded, dict) else {"raw": raw}
+
+
+def _collect_text_variables(content: str) -> dict[str, Any]:
+    """``name_raw: <json>`` lines the model emits before referencing them by name."""
+    variables: dict[str, Any] = {}
+    for line in content.splitlines():
+        match = _TEXT_VAR_RE.match(line)
+        if not match or not match.group("name").endswith("_raw"):
+            continue
+        value_text = match.group("value").strip()
+        try:
+            variables[match.group("name")] = json.loads(value_text)
+        except Exception:
+            variables[match.group("name")] = value_text.strip('"')
+    return variables
+
+
+def _as_tool_call(index: int, name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": f"text-tool-call-{index}",
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args, sort_keys=True)},
+    }
+
+
+def _find_multiline_bare_calls(text: str, *, known_names: set[str]) -> list[tuple[str, str, int, int]]:
+    """Find ``name(...)`` calls whose arguments span multiple lines.
+
+    ``_BARE_TOOL_CALL_RE`` only matches a call that is a whole physical line,
+    which misses models that write a tool call as pretty-printed JSON args across
+    several lines, e.g. ``run_skill_script({\n  "skill": ...\n})``.
+    Restricted to declared tool names so this never mistakes prose like
+    "the discount (25%)" for a call.
+    """
+    calls: list[tuple[str, str, int, int]] = []
+    for match in _BARE_CALL_HEAD_RE.finditer(text):
+        name = match.group("name")
+        if name not in known_names:
+            continue
+        depth = 1
+        i = match.end()
+        while i < len(text) and depth > 0:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        if depth == 0:
+            calls.append((name, text[match.end() : i - 1], match.start(), i))
+    return calls

--- a/runtime/tests/test_llm_live_textual_tool_calls.py
+++ b/runtime/tests/test_llm_live_textual_tool_calls.py
@@ -1,0 +1,100 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Regression tests for textual tool-call markup fallback parsing."""
+
+from __future__ import annotations
+
+from mas.runtime.engine.llm_live import LiveLlmEngine
+from mas.runtime.engine.textual_tool_calls import (
+    recover_tool_calls_from_content,
+    repair_merged_arg_keys,
+    strip_channel_markup,
+)
+from mas.runtime.schema.egress import InvokeEngineIo
+
+
+def test_strip_channel_markup_removes_channel_tokens() -> None:
+    text = "<|channel>thought\n<channel|>I recommend 20%."
+    assert strip_channel_markup(text) == "I recommend 20%."
+
+
+def test_strip_channel_markup_handles_sentinel_only_output() -> None:
+    assert strip_channel_markup("<|channel>thought") == ""
+
+
+def test_recover_tool_calls_from_content_parses_multiple_calls() -> None:
+    content = (
+        '<|tool_call>call:activate_skill(name:<|"|>evidence-grounded-specialist<|"|>)<tool_call|>'
+        '<|tool_call>call:query_salesforce_opportunity(account_name:<|"|>Acme<|"|>)<tool_call|>'
+    )
+
+    tool_calls, cleaned = recover_tool_calls_from_content(content)
+
+    assert cleaned == ""
+    assert [item["function"]["name"] for item in tool_calls] == [
+        "activate_skill",
+        "query_salesforce_opportunity",
+    ]
+    assert '"account_name": "Acme"' in tool_calls[1]["function"]["arguments"]
+
+
+def test_recover_tool_calls_from_content_parses_multiline_bare_call() -> None:
+    content = 'run_skill_script({\n  "skill": "demo",\n  "args": ["record", "item-1"]\n})'
+
+    tool_calls, cleaned = recover_tool_calls_from_content(
+        content,
+        known_tool_names={"run_skill_script"},
+    )
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "run_skill_script"
+    assert '"skill": "demo"' in tool_calls[0]["function"]["arguments"]
+    assert cleaned == ""
+
+
+def test_repair_merged_arg_keys_splits_glued_array_key() -> None:
+    repaired = repair_merged_arg_keys(
+        {
+            'args=["record", "item-1"],script': "runner.py",
+            "skill": "demo",
+        }
+    )
+
+    assert repaired == {
+        "args": ["record", "item-1"],
+        "script": "runner.py",
+        "skill": "demo",
+    }
+
+
+def test_live_engine_uses_textual_tool_call_fallback_for_tool_loop() -> None:
+    engine = LiveLlmEngine(use_tool_loop=True, use_cache=False)
+    io = InvokeEngineIo(correlation_id=7, op="LLM_CALL")
+    message = {
+        "role": "assistant",
+        "content": '<|tool_call>call:activate_skill(name:<|"|>demo-answer-metadata-format<|"|>)<tool_call|>',
+    }
+
+    ret = engine._message_to_engine_return(
+        io,
+        message,
+        [{"role": "user", "content": "hi"}],
+        [],
+        False,
+        {},
+        "stop",
+    )
+
+    assert ret.next_step == "TOOL_CALL"
+    assert ret.tool_name == "activate_skill"
+    assert ret.tool_arguments == {"name": "demo-answer-metadata-format"}
+
+
+def test_recover_tool_calls_from_content_parses_bare_tool_plan_with_variable_binding() -> None:
+    content = '- salesforce_agent_raw: "hello world"\n- sanitize_demo_metadata(salesforce_agent_raw)'
+
+    tool_calls, _cleaned = recover_tool_calls_from_content(content)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "sanitize_demo_metadata"
+    assert '"value": "hello world"' in tool_calls[0]["function"]["arguments"]


### PR DESCRIPTION
- Add textual_tool_calls fallback module for backends that emit calls in message content.
- Parse tool calls when structured tool_calls are absent, including multiline and merged-key forms.
- Convert recovered calls into the existing structured tool execution path.
- Add regression coverage for the supported textual formats.
