### PR TITLE
fix(context): provider-safe assembly after history trim (supersedes #55)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Guidelines
+
+## Core Principles
+
+- **Verification:** Always run the `verify` task after completing any change.
+- **No pre-existing failures:** Never leave lint, type, or test failures open — even if they
+  predate your edit. Fix them in the same change set when you touch the file or discover them
+  during review prep.
+- **Remote Operations:** NEVER push to a remote repository without explicit approval from the user.
+- **Commit Messages:**
+    - Must be succinct and crisp.
+    - Detail only implemented features in a bullet list.
+    - Use a TLDR-style format.
+    - **NEVER** write the literal string "TLDR" in the commit message.
+- **Environment & Reproducibility:**
+    - Always use `uv` in conjunction with the `direnv` environment.
+    - Do not run manual `pip install` commands; instead, update the project's `pyproject.toml` or use `uv add` to ensure dependencies are captured and the environment remains reproducible.
+
+## Task Completion Workflow
+
+1. Implement the change.
+2. Run `task verify`.
+3. If verification passes, prepare the commit.
+4. Draft the commit message following the guidelines above.
+5. Request approval for the commit and subsequent push.

--- a/library-standard/src/mas/library/standard/plugins/context/assembler.py
+++ b/library-standard/src/mas/library/standard/plugins/context/assembler.py
@@ -73,14 +73,14 @@ The conversation-history transformation always runs (not gated by the marker).
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from mas.runtime.contracts.base import BasePlugin
 from mas.runtime.contracts.cm_factory import CMFactory
 from mas.runtime.contracts.context_contract import (
+    _SYSTEM_PLACEMENTS_ORDER,
     ContextPart,
     ContextPlacement,
-    _SYSTEM_PLACEMENTS_ORDER,
 )
 from mas.runtime.contracts.context_manager_contract import ContextManagerContract
 
@@ -167,6 +167,7 @@ class _NoOpContextManager(ContextManagerContract):
 # ---------------------------------------------------------------------------
 # ContextAssemblerPlugin
 # ---------------------------------------------------------------------------
+
 
 class ContextAssemblerPlugin(BasePlugin):
     """Collects ContextParts from all registered ContextContract plugins and
@@ -293,22 +294,21 @@ class ContextAssemblerPlugin(BasePlugin):
                 hook_data["_evicted_parts"] = [
                     {
                         "section_id": p.section_id,
-                        "source":     p.source,
-                        "role":       p.role or p.source,
-                        "tokens":     p.token_estimate,
-                        "mechanism":  getattr(p.provenance, "mechanism", "collect_context"),
-                        "trigger":    getattr(p.provenance, "trigger", "runtime_default"),
+                        "source": p.source,
+                        "role": p.role or p.source,
+                        "tokens": p.token_estimate,
+                        "mechanism": getattr(p.provenance, "mechanism", "collect_context"),
+                        "trigger": getattr(p.provenance, "trigger", "runtime_default"),
                         "source_type": getattr(p.provenance, "source_type", "unknown"),
                         "sensitivity": getattr(p.provenance, "sensitivity", ""),
                     }
-                    for p in all_parts_raw if id(p) not in kept_ids
+                    for p in all_parts_raw
+                    if id(p) not in kept_ids
                 ]
 
         # Sort: placement order first, then priority within placement
         placement_order = {pl: i for i, pl in enumerate(_SYSTEM_PLACEMENTS_ORDER)}
-        system_parts = [
-            p for p in all_parts if p.placement in placement_order
-        ]
+        system_parts = [p for p in all_parts if p.placement in placement_order]
         system_parts.sort(key=lambda p: (placement_order.get(p.placement, 99), p.priority))
 
         user_prepend_parts = sorted(
@@ -352,9 +352,9 @@ class ContextAssemblerPlugin(BasePlugin):
         recorder = getattr(getattr(self, "agent", None), "recorder", None)
         if recorder is not None and self._emit_segments:
             import time as _time
+
             _ts = _time.time()
             _agent_id = getattr(self, "agent_id", "unknown")
-            evicted_ids = {p.get("section_id") for p in hook_data.get("_evicted_parts", [])}
             for part in ordered_all:
                 prov = part.provenance
                 _evt = {
@@ -436,8 +436,12 @@ class ContextAssemblerPlugin(BasePlugin):
             if isinstance(existing, list):
                 # Content is a multimodal array — prepend text block to the list
                 from mas.runtime.contracts.content_types import ContentPart
+
                 new_parts = [ContentPart.text_part(block)] + list(existing)
-                messages[sys_idx] = {"role": "system", "content": [p.to_dict() if isinstance(p, ContentPart) else p for p in new_parts]}
+                messages[sys_idx] = {
+                    "role": "system",
+                    "content": [p.to_dict() if isinstance(p, ContentPart) else p for p in new_parts],
+                }
             else:
                 messages[sys_idx] = {"role": "system", "content": existing.rstrip() + "\n\n" + block}
         else:
@@ -467,6 +471,7 @@ class ContextAssemblerPlugin(BasePlugin):
         # Handle multimodal content — use merge_content from content_types
         if isinstance(current, list):
             from mas.runtime.contracts.content_types import ContentPart as CP
+
             if prepend_parts:
                 prefix_text = "\n\n".join(p.content for p in prepend_parts)
                 new_parts = [CP.text_part(prefix_text)] + list(current)
@@ -509,8 +514,10 @@ class ContextAssemblerPlugin(BasePlugin):
         if isinstance(self._conv_strategy, _NoOpContextManager):
             return messages  # no-op, fast path
 
+        from mas.library.standard.plugins.context.provider_payload import sanitize_provider_messages
+
         system_msgs = [m for m in messages if m.get("role") == "system"]
-        turn_msgs = [m for m in messages if m.get("role") in ("user", "assistant")]
+        turn_msgs = [m for m in messages if m.get("role") in ("user", "assistant", "tool")]
 
         # Find the last user message — that's the current (live) turn
         last_user_idx: Optional[int] = None
@@ -526,17 +533,14 @@ class ContextAssemblerPlugin(BasePlugin):
         past = turn_msgs[:last_user_idx]
         current_and_after = turn_msgs[last_user_idx:]
 
-        managed_past = self._conv_strategy.manage_history(
-            past, self._token_budget or 0
-        )
+        managed_past = self._conv_strategy.manage_history(past, self._token_budget or 0)
         # Detect summarisation: if managed_past is shorter than past, turns
         # were either removed (SlidingWindowConversation) or compressed into a
         # summary block (SummarizingConversation).  Store on self so
         # on_pre_llm_call can pass _summarized_turns to ObservabilityPlugin.
         self._last_summarized_turns = max(0, len(past) - len(managed_past))
         # C5: expose compaction evidence metadata if the strategy tracks it
-        self._last_compaction_metadata = getattr(
-            self._conv_strategy, "last_compaction_metadata", None
-        )
+        self._last_compaction_metadata = getattr(self._conv_strategy, "last_compaction_metadata", None)
 
-        return system_msgs + managed_past + current_and_after
+        completed = sanitize_provider_messages(system_msgs + managed_past)
+        return completed + current_and_after

--- a/library-standard/src/mas/library/standard/plugins/context/provider_payload.py
+++ b/library-standard/src/mas/library/standard/plugins/context/provider_payload.py
@@ -1,0 +1,98 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Provider-safe OpenAI-shaped message lists after trimming or compaction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def tool_call_pairs(messages: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """Return (declared tool_call ids, tool-result ids) for invariant checks."""
+    declared = {str(c["id"]) for m in messages if m.get("tool_calls") for c in m["tool_calls"] if c.get("id")}
+    returned = {str(m["tool_call_id"]) for m in messages if m.get("role") == "tool" and m.get("tool_call_id")}
+    return declared, returned
+
+
+def assert_provider_payload(messages: list[dict[str, Any]]) -> None:
+    """Bedrock-style invariant: every tool result references a declared tool_call id."""
+    declared, returned = tool_call_pairs(messages)
+    orphan = returned - declared
+    assert not orphan, f"orphan tool results: {orphan}"
+
+
+def sanitize_provider_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove invalid tool fragments from *completed* history.
+
+    Only pass committed/trimmed history — never the live in-turn tail (working
+    memory or the current user turn), which may contain in-flight tool_calls.
+    """
+    if not messages:
+        return []
+    return _sanitize_completed(messages)
+
+
+def _repair_tool_call_bindings(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Rebind mismatched tool_call_id values (e.g. HITL steering) before orphan drop."""
+    repaired: list[dict[str, Any]] = []
+    unresolved: set[str] = set()
+
+    for msg in messages:
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            repaired.append(msg)
+            unresolved = {str(c.get("id")) for c in msg["tool_calls"] if c.get("id")}
+            continue
+
+        if msg.get("role") == "tool" and unresolved:
+            tool_id = str(msg.get("tool_call_id") or "")
+            if tool_id not in unresolved:
+                rebound = dict(msg)
+                rebound["tool_call_id"] = sorted(unresolved)[0]
+                repaired.append(rebound)
+                unresolved.discard(rebound["tool_call_id"])
+                continue
+            unresolved.discard(tool_id)
+            repaired.append(msg)
+            continue
+
+        if msg.get("role") != "tool":
+            unresolved = set()
+        repaired.append(msg)
+    return repaired
+
+
+def _sanitize_completed(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not messages:
+        return []
+
+    messages = _repair_tool_call_bindings(messages)
+    declared = tool_call_pairs(messages)[0]
+    without_orphan_tools = [
+        msg for msg in messages if msg.get("role") != "tool" or str(msg.get("tool_call_id") or "") in declared
+    ]
+
+    sanitized: list[dict[str, Any]] = []
+    i = 0
+    while i < len(without_orphan_tools):
+        msg = without_orphan_tools[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            call_ids = {str(c.get("id")) for c in msg["tool_calls"] if c.get("id")}
+            j = i + 1
+            found: set[str] = set()
+            while j < len(without_orphan_tools) and without_orphan_tools[j].get("role") == "tool":
+                tool_id = without_orphan_tools[j].get("tool_call_id")
+                if tool_id:
+                    found.add(str(tool_id))
+                j += 1
+            if call_ids and call_ids <= found:
+                sanitized.extend(without_orphan_tools[i:j])
+                i = j
+                continue
+            stripped = {k: v for k, v in msg.items() if k != "tool_calls"}
+            if str(stripped.get("content") or "").strip():
+                sanitized.append(stripped)
+            i += 1
+            continue
+        sanitized.append(msg)
+        i += 1
+    return sanitized

--- a/library-standard/src/mas/library/standard/plugins/context/token_budget.py
+++ b/library-standard/src/mas/library/standard/plugins/context/token_budget.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 
 def estimate_tokens(messages: list[dict[str, Any]]) -> int:
@@ -19,54 +22,41 @@ def estimate_tokens(messages: list[dict[str, Any]]) -> int:
     return total // 4 + len(messages) * 4
 
 
-def _skip_tool_group(tail: list[dict[str, Any]], start: int) -> int:
-    """Return how many messages to drop starting at *start* to keep tool pairs intact.
-
-    If ``tail[start]`` is an assistant message with ``tool_calls``, we must also
-    drop every subsequent ``tool`` response that references one of those calls.
-    If ``tail[start]`` is an orphaned ``tool`` message, drop it too.
-    """
-    msg = tail[start]
-    if msg.get("role") == "assistant" and msg.get("tool_calls"):
-        call_ids = {c.get("id") for c in msg["tool_calls"] if c.get("id")}
-        count = 1
-        while start + count < len(tail):
-            nxt = tail[start + count]
-            if nxt.get("role") == "tool" and nxt.get("tool_call_id") in call_ids:
-                count += 1
-            else:
-                break
-        return count
-    if msg.get("role") == "tool":
-        return 1
-    return 1
-
-
 def trim_messages_to_budget(
     messages: list[dict[str, Any]],
     *,
     max_tokens: int,
     reserve_tokens: int = 0,
+    pin_tail: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Drop oldest non-system messages until estimated tokens fit the budget.
 
-    Tool-call groups (an assistant message with ``tool_calls`` followed by
-    matching ``tool`` responses) are dropped atomically so the resulting list
-    never contains orphaned ``tool`` messages.
+    ``pin_tail`` is appended after trimming and never removed. Assembly uses
+    this for structurally pinned in-turn working memory while outbound waits are
+    active on the kernel ledger.
     """
     if max_tokens <= 0:
-        return list(messages)
+        return list(messages) + list(pin_tail or [])
     budget = max(0, max_tokens - max(0, reserve_tokens))
-    if estimate_tokens(messages) <= budget:
-        return list(messages)
+    pinned_tail = list(pin_tail or [])
+    if estimate_tokens(messages + pinned_tail) <= budget:
+        return list(messages) + pinned_tail
 
-    pinned: list[dict[str, Any]] = []
+    head: list[dict[str, Any]] = []
     tail = list(messages)
     if tail and tail[0].get("role") == "system":
-        pinned.append(tail.pop(0))
-    while tail and estimate_tokens(pinned + tail) > budget and len(tail) > 1:
-        n = _skip_tool_group(tail, 0)
-        if n >= len(tail):
-            break
-        del tail[:n]
-    return pinned + tail
+        head.append(tail.pop(0))
+    while tail and estimate_tokens(head + tail + pinned_tail) > budget and len(tail) > 1:
+        del tail[0]
+    result = head + tail + pinned_tail
+    over = estimate_tokens(result)
+    if over > budget:
+        _log.warning(
+            "token budget %d exceeded by pinned messages alone (~%d tokens, "
+            "%d pinned tail message(s)): raise the context budget or reduce "
+            "what is injected into the prompt",
+            budget,
+            over,
+            len(pinned_tail),
+        )
+    return result

--- a/library-standard/tests/test_provider_payload.py
+++ b/library-standard/tests/test_provider_payload.py
@@ -1,0 +1,198 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Provider payload repair for committed history after trimming (PR #55 regressions)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mas.library.standard.plugins.context.assembler import ContextAssemblerPlugin
+from mas.library.standard.plugins.context.conversation import (
+    SlidingWindowConversation,
+    StackConversation,
+    SummarizingConversation,
+)
+from mas.library.standard.plugins.context.provider_payload import (
+    assert_provider_payload,
+    sanitize_provider_messages,
+    tool_call_pairs,
+)
+from mas.library.standard.plugins.context.token_budget import trim_messages_to_budget
+
+
+def _tool_turn(call_id: str = "call_1", *, content: str = "result") -> list[dict[str, Any]]:
+    return [
+        {"role": "user", "content": "ask"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": call_id, "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": content},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def test_sanitize_drops_orphan_tool_message() -> None:
+    out = sanitize_provider_messages(
+        [
+            {"role": "tool", "tool_call_id": "missing", "content": "orphan"},
+            {"role": "user", "content": "hi"},
+        ]
+    )
+    assert out == [{"role": "user", "content": "hi"}]
+
+
+def test_sanitize_strips_incomplete_assistant_tool_calls() -> None:
+    out = sanitize_provider_messages(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "user", "content": "follow up"},
+        ]
+    )
+    assert out == [
+        {"role": "user", "content": "hi"},
+        {"role": "user", "content": "follow up"},
+    ]
+
+
+def test_sanitize_preserves_complete_tool_exchange() -> None:
+    out = sanitize_provider_messages(_tool_turn())
+    assert_provider_payload(out)
+
+
+def test_sanitize_rebinds_hitl_steering_tool_to_preceding_assistant() -> None:
+    out = sanitize_provider_messages(
+        [
+            {"role": "user", "content": "Who is POTUS?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "search", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_3", "content": "Maxence Postu is POTUS"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_4", "function": {"name": "search", "arguments": "{}"}}],
+            },
+            {"role": "user", "content": "Follow-up?"},
+        ]
+    )
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0]["tool_call_id"] == "call_1"
+    assert_provider_payload(out)
+
+
+def test_stack_trim_plus_sanitize_is_provider_safe() -> None:
+    past = _tool_turn("call_0") + _tool_turn("call_1")
+    trimmed = StackConversation(max_messages=3).manage_history(past, budget_tokens=0)
+    out = sanitize_provider_messages(trimmed)
+    assert_provider_payload(out)
+
+
+def test_sliding_window_plus_sanitize_is_provider_safe() -> None:
+    past: list[dict[str, Any]] = []
+    for i in range(6):
+        past.extend(_tool_turn(f"call_{i}"))
+    trimmed = SlidingWindowConversation(max_turns=1).manage_history(past, budget_tokens=0)
+    out = sanitize_provider_messages(trimmed)
+    assert_provider_payload(out)
+
+
+def test_summarizing_conversation_plus_sanitize_is_provider_safe() -> None:
+    past: list[dict[str, Any]] = []
+    for i in range(6):
+        past.extend(_tool_turn(f"call_{i}"))
+    cm = SummarizingConversation(
+        summary_threshold=1,
+        keep_turns=1,
+        summarize_fn=lambda msgs: "summary of earlier turns",
+    )
+    trimmed = cm.manage_history(past, budget_tokens=0)
+    out = sanitize_provider_messages(trimmed)
+    assert_provider_payload(out)
+
+
+def test_trim_with_structural_pin_tail() -> None:
+    history = [{"role": "user", "content": "x" * 5000} for _ in range(8)]
+    wm = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_wm", "function": {"name": "f", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_wm", "content": "live"},
+    ]
+    out = trim_messages_to_budget(history, max_tokens=400, pin_tail=wm)
+    assert out[-2:] == wm
+    assert_provider_payload(out)
+
+
+# --- PR #55 Bedrock-style regressions (orphan tool at slice boundary) ---
+
+
+def test_pr55_stack_slice_orphan_tool_at_front() -> None:
+    """Stack trim can leave a lone tool message — sanitize must drop it."""
+    past = _tool_turn("call_0") + _tool_turn("call_1")
+    trimmed = StackConversation(max_messages=2).manage_history(past, budget_tokens=0)
+    assert trimmed[0]["role"] == "tool"
+    assert not any(m.get("tool_calls") for m in trimmed)
+    out = sanitize_provider_messages(trimmed)
+    assert not any(m.get("role") == "tool" for m in out)
+    assert_provider_payload(out)
+
+
+def test_pr55_stack_various_max_messages_never_violate_invariant() -> None:
+    past: list[dict[str, Any]] = []
+    for i in range(10):
+        past.extend(_tool_turn(f"call_{i}"))
+    for max_msgs in range(1, 20):
+        trimmed = StackConversation(max_messages=max_msgs).manage_history(past, budget_tokens=0)
+        out = sanitize_provider_messages(trimmed)
+        declared, returned = tool_call_pairs(out)
+        assert returned <= declared
+        assert_provider_payload(out)
+
+
+def test_pr55_sliding_window_split_exchange() -> None:
+    past: list[dict[str, Any]] = []
+    for i in range(8):
+        past.extend(_tool_turn(f"call_{i}"))
+    trimmed = SlidingWindowConversation(max_turns=2).manage_history(past, budget_tokens=0)
+    out = sanitize_provider_messages(trimmed)
+    assert_provider_payload(out)
+
+
+def test_pr55_token_budget_many_sizes_on_tool_history() -> None:
+    past: list[dict[str, Any]] = []
+    for i in range(6):
+        past.extend(_tool_turn(f"call_{i}", content=f"payload-{i}-" + "x" * 200))
+    for budget in (50, 100, 200, 400, 800, 1600, 3200):
+        out = trim_messages_to_budget(past, max_tokens=budget)
+        out = sanitize_provider_messages(out)
+        assert_provider_payload(out)
+
+
+def test_pr55_assembler_end_to_end_with_live_tool_exchange() -> None:
+    plugin = ContextAssemblerPlugin(conversation_strategy=StackConversation(max_messages=6))
+    history = _tool_turn("call_0") + _tool_turn("call_1") + _tool_turn("call_2")
+    history.append({"role": "user", "content": "current question"})
+    history.append(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_live", "function": {"name": "f", "arguments": "{}"}}],
+        }
+    )
+    out = plugin._apply_conversation_strategy(history)
+    declared, returned = tool_call_pairs(out)
+    assert "call_live" in declared
+    assert returned <= declared
+    assert_provider_payload(out)

--- a/runtime/src/mas/runtime/boundary/context/assemble.py
+++ b/runtime/src/mas/runtime/boundary/context/assemble.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from mas.library.standard.plugins.context.provider_payload import sanitize_provider_messages
 from mas.runtime.boundary.context.trim import context_manager_spec
-from mas.runtime.boundary.context.working_memory import (
-    WorkingMemoryStore,
-    working_memory_source,
-)
+from mas.runtime.boundary.context.working_memory import WorkingMemoryStore
 from mas.runtime.contracts.cm_factory import CMFactory
 
 
@@ -35,18 +33,16 @@ def _token_budget_params(manifest: dict | None) -> tuple[int | None, int]:
         return None, 512
 
 
-def _apply_token_budget(
-    messages: list[dict[str, Any]],
-    manifest: dict | None,
-) -> list[dict[str, Any]]:
-    max_tokens, reserve = _token_budget_params(manifest)
-    if max_tokens is None:
-        return messages
-    from mas.library.standard.plugins.context.token_budget import trim_messages_to_budget
+def _pinned_working_memory(ctx: Any) -> list[dict[str, Any]]:
+    """In-turn working memory is structurally pinned from budget trimming.
 
-    return trim_messages_to_budget(
-        messages, max_tokens=max_tokens, reserve_tokens=reserve
-    )
+    Each session/ctx carries its own ``WorkingMemoryStore``; assembly never
+    reads global kernel state for message content.
+    """
+    store = getattr(ctx, "working_memory", None)
+    if isinstance(store, WorkingMemoryStore) and store.messages:
+        return list(store.messages)
+    return []
 
 
 def assemble_llm_messages(
@@ -55,10 +51,7 @@ def assemble_llm_messages(
     manifest: dict | None = None,
     correlation_id: int = 0,
 ) -> list[dict[str, Any]]:
-    """Build OpenAI-shaped messages: system → committed history → user → in-turn working memory."""
-    store = getattr(ctx, "working_memory", None) or WorkingMemoryStore()
-    wm = working_memory_source(store)
-
+    """Build OpenAI-shaped messages: system → committed history → user → pinned WM."""
     messages: list[dict[str, Any]] = []
     system_parts: list[str] = []
     for line in getattr(ctx, "injected_context", []) or []:
@@ -66,11 +59,6 @@ def assemble_llm_messages(
             system_parts.append(str(line).strip())
     for key, content in getattr(ctx, "memory_seeds", []) or []:
         system_parts.append(f"[memory:{key}] {content}")
-    # ctx_collect_execute — v0.1 wiring: call collect_context() on all registered
-    # ContextContract plugins via plugin_collection.collect_results().
-    # This uses the same interface that ContextAssemblerPlugin.on_pre_llm_call()
-    # expects as agent.registry — so when the full assembler is wired into the
-    # kernel this bridge can be removed without changing plugin behavior.
     _inject_context_plugins(ctx, system_parts)
     if system_parts:
         messages.append({"role": "system", "content": "\n\n".join(system_parts)})
@@ -79,22 +67,32 @@ def assemble_llm_messages(
     if committed:
         past = list(committed)
     else:
-        turn_history = list(getattr(ctx, "turn_history", []) or [])
-        past = _turn_history_to_past(turn_history)
-    cm = CMFactory.create(manifest=manifest)
-    max_tokens, _ = _token_budget_params(manifest)
-    managed = cm.manage_history(past, max_tokens or 0)
+        past = _turn_history_to_past(list(getattr(ctx, "turn_history", []) or []))
+    managed = CMFactory.create(manifest=manifest).manage_history(past, _token_budget_params(manifest)[0] or 0)
     messages.extend(managed)
 
     last_user_text = str(getattr(ctx, "last_user_text", "") or "")
     if last_user_text:
         messages.append({"role": "user", "content": last_user_text})
 
-    messages.extend(wm.collect_context(manifest=manifest))
+    wm_messages = _pinned_working_memory(ctx)
 
-    if not messages:
+    if not messages and not wm_messages:
         messages.append({"role": "user", "content": "Hello"})
-    messages = _apply_token_budget(messages, manifest)
+
+    messages = sanitize_provider_messages(messages)
+    max_tokens, reserve = _token_budget_params(manifest)
+    if max_tokens is not None:
+        from mas.library.standard.plugins.context.token_budget import trim_messages_to_budget
+
+        messages = trim_messages_to_budget(
+            messages,
+            max_tokens=max_tokens,
+            reserve_tokens=reserve,
+            pin_tail=wm_messages,
+        )
+    else:
+        messages = messages + wm_messages
 
     from mas.runtime.boundary.context.telemetry import record_context_assembly
 
@@ -110,38 +108,21 @@ def assemble_llm_messages(
     return messages
 
 
-def _has_tool_results(messages: list[dict[str, Any]]) -> bool:
-    return any(m.get("role") == "tool" for m in messages)
-
-
 def _inject_context_plugins(ctx: Any, system_parts: list[str]) -> None:
-    """Dispatch ctx_collect_execute to registered ContextContract plugins.
-
-    Calls ``plugin_collection.collect_results("collect_context")`` on the
-    context object's ``plugin_collection`` (a ``PluginCollection`` instance).
-    Gathered ``ContextPart`` objects are sorted by placement order + priority
-    before their content is appended to *system_parts*.
-
-    This is the v0.1 bridge for the ctx_collect_execute FSM symbol.  It uses
-    the same ``collect_results()`` interface that ``ContextAssemblerPlugin``
-    expects as ``agent.registry``, so the bridge can be removed once the full
-    assembler plugin is wired into the kernel without any change to plugins.
-    """
     collection = getattr(ctx, "plugin_collection", None)
     if not collection:
         return
 
     from mas.runtime.contracts.context_contract import (
+        _SYSTEM_PLACEMENTS_ORDER,
         ContextPart,
         ContextPlacement,
-        _SYSTEM_PLACEMENTS_ORDER,
     )
 
     raw_parts = collection.collect_results("collect_context")
     if not raw_parts:
         return
 
-    # Sort by placement band then priority, matching ContextAssemblerPlugin order.
     placement_order = {pl: i for i, pl in enumerate(_SYSTEM_PLACEMENTS_ORDER)}
 
     def _sort_key(part: Any) -> tuple[int, int]:
@@ -149,12 +130,10 @@ def _inject_context_plugins(ctx: Any, system_parts: list[str]) -> None:
         priority = getattr(part, "priority", 60)
         return (placement_order.get(placement, 99), priority)
 
-    sorted_parts = sorted(
+    for part in sorted(
         (p for p in raw_parts if isinstance(p, ContextPart)),
         key=_sort_key,
-    )
-
-    for part in sorted_parts:
+    ):
         if str(part.content).strip():
             system_parts.append(str(part.content).strip())
 
@@ -164,18 +143,8 @@ def llm_request_tools(
     *,
     tools: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]] | None:
-    """Tools for the API payload.
-
-    Tools stay available after tool results so ReAct loops can issue further
-    ``tool_calls`` (e.g. chained ``delegate_to_*``).
-
-    ``messages`` is retained for call-site compatibility and future guards
-    (e.g. post-tool synthesis); it is not read in the current ReAct-only path.
-    """
     _ = messages
-    if not tools:
-        return None
-    return tools
+    return tools or None
 
 
 def llm_tool_choice(
@@ -183,14 +152,12 @@ def llm_tool_choice(
     *,
     tools: list[dict[str, Any]] | None,
 ) -> str | None:
-    """OpenAI tool_choice when tools are included.
-
-    ``messages`` is retained for call-site compatibility; not read currently.
-    """
     _ = messages
-    if not tools:
-        return None
-    return "auto"
+    return "auto" if tools else None
+
+
+def has_tool_results(messages: list[dict[str, Any]]) -> bool:
+    return any(m.get("role") == "tool" for m in messages)
 
 
 __all__ = [
@@ -199,7 +166,3 @@ __all__ = [
     "llm_request_tools",
     "llm_tool_choice",
 ]
-
-
-def has_tool_results(messages: list[dict[str, Any]]) -> bool:
-    return _has_tool_results(messages)

--- a/runtime/src/mas/runtime/boundary/context/working_memory.py
+++ b/runtime/src/mas/runtime/boundary/context/working_memory.py
@@ -114,11 +114,6 @@ class WorkingMemoryContextSource:
             return []
         msgs = self.store.messages
         start = max(0, len(msgs) - limit)
-        # Don't slice into the middle of a tool-call group: if the first
-        # message after slicing is a "tool" response, back up to include
-        # the preceding assistant message with tool_calls.
-        while start > 0 and msgs[start].get("role") == "tool":
-            start -= 1
         return list(msgs[start:])
 
 

--- a/runtime/src/mas/runtime/driver/driver.py
+++ b/runtime/src/mas/runtime/driver/driver.py
@@ -11,20 +11,20 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Any, Literal
 
+from mas.runtime.boundary.coordination.chokepoint import ChokepointCoordinator
 from mas.runtime.boundary.hitl.responders import HitlResponder
 from mas.runtime.boundary.ingress_validate import validate_ingress
-from mas.runtime.kernel.inflight import pending_for_validate, register_inflight
-from mas.runtime.boundary.coordination.chokepoint import ChokepointCoordinator
-from mas.runtime.kernel.runtime_context import runtime_binding
-from mas.runtime.machines.gov import gov_is_hitl_pending
 from mas.runtime.boundary.obs.exchange_plugin import ExchangePlugin
 from mas.runtime.boundary.obs.operator import ObservabilityOperator
+from mas.runtime.driver.mocks import AutoCtxAssembler
 from mas.runtime.engine.simulated import SimulatedEngine
 from mas.runtime.engine.worker_pool import EngineWorkerPool
-from mas.runtime.kernel.orchestrator import RuntimeKernel, StepResult
-from mas.runtime.driver.mocks import AutoCtxAssembler
+from mas.runtime.kernel.inflight import pending_for_validate, register_inflight
+from mas.runtime.kernel.orchestrator import RuntimeKernel
+from mas.runtime.kernel.runtime_context import runtime_binding
+from mas.runtime.machines.gov import gov_is_hitl_pending
 from mas.runtime.schema.egress import (
     EgressKind,
     EgressSymbol,
@@ -156,9 +156,7 @@ class KernelDriver:
             ingress = queue.popleft()
             if not validate_ingress(
                 ingress,
-                last_correlation_id=(
-                    self.kernel.run.records[-1].correlation_id if self.kernel.run.records else 0
-                ),
+                last_correlation_id=(self.kernel.run.records[-1].correlation_id if self.kernel.run.records else 0),
                 pending_correlation_id=self.kernel.q.pending_engine_correlation_id,
                 inflight_correlation_ids=pending_for_validate(self.kernel.q),
             ):
@@ -182,9 +180,7 @@ class KernelDriver:
                     # Same values, same source, as what governance sees on
                     # this and every subsequent transition this turn (see
                     # _notify_governance) — so observability logs match.
-                    self.observability.set_context(
-                        session_id=self.session_id, task_id=self._current_task_id
-                    )
+                    self.observability.set_context(session_id=self.session_id, task_id=self._current_task_id)
                 if self.ctx is not None:
                     # Emit USER->AGENT exchange for trace visibility
                     ts_mono, ts_wall = _exchange_timestamp()
@@ -263,9 +259,7 @@ class KernelDriver:
             merged.awaiting_hitl = part.awaiting_hitl
         return merged
 
-    def _dispatch_egress(
-        self, sym: EgressSymbol, trace: DriverTrace
-    ) -> list[IngressSymbol]:
+    def _dispatch_egress(self, sym: EgressSymbol, trace: DriverTrace) -> list[IngressSymbol]:
         if sym.kind == EgressKind.INVOKE_ENGINE_IO:
             assert isinstance(sym, InvokeEngineIo)
             return self._dispatch_engine_batch([sym], trace)
@@ -323,9 +317,7 @@ class KernelDriver:
         for plugin in self.exchange_plugins:
             plugin.on_exchange(record)
 
-    def _notify_governance(
-        self, hook: Literal["ingress", "egress"], symbol: IngressSymbol | EgressSymbol
-    ) -> None:
+    def _notify_governance(self, hook: Literal["ingress", "egress"], symbol: IngressSymbol | EgressSymbol) -> None:
         """Give the governance plugin every ingress/egress symbol, read-only.
 
         Single hook (``on_transition(GovTransition)``), not one bespoke
@@ -383,9 +375,7 @@ class KernelDriver:
         except Exception:
             _logger.debug("governance plugin on_transition failed", exc_info=True)
 
-    def _dispatch_engine_batch(
-        self, ios: list[InvokeEngineIo], trace: DriverTrace
-    ) -> list[IngressSymbol]:
+    def _dispatch_engine_batch(self, ios: list[InvokeEngineIo], trace: DriverTrace) -> list[IngressSymbol]:
         q = self.kernel.q
         engine = self.engine
         pool = self.engine_pool
@@ -396,9 +386,7 @@ class KernelDriver:
         if len(ios) > 1 and all(sym.op == "TOOL_CALL" for sym in ios):
             self._record_parallel_tool_calls(ios, q)
             parallel_group_id = str(uuid.uuid4())
-            self._record_parallel_group_obs(
-                ios, q, boundary="start", group_id=parallel_group_id
-            )
+            self._record_parallel_group_obs(ios, q, boundary="start", group_id=parallel_group_id)
         for sym in ios:
             preview = ""
             tool_name_for_detail = ""  # Extract tool name for exchange detail
@@ -411,7 +399,7 @@ class KernelDriver:
                     tool_name_for_detail = by_cid[0]  # Extract tool name
                 elif sym.op == "TOOL_CALL" and q.pending_tool_name:
                     from mas.runtime.engine.exchange_preview import format_tool_invoke
-                    
+
                     preview = format_tool_invoke(q.pending_tool_name, q.pending_tool_args)
                     tool_name_for_detail = q.pending_tool_name
                 else:
@@ -460,7 +448,8 @@ class KernelDriver:
                     setter = getattr(engine, "set_scheduled_tool", None)
                     if callable(setter):
                         setter(q.pending_tool_name, q.pending_tool_args)
-            register_inflight(q, sym.correlation_id)
+            egress_kind = "MODEL" if sym.op == "LLM_CALL" else "TOOL"
+            register_inflight(q, sym.correlation_id, kind=egress_kind, op=sym.op)
             from mas.runtime.boundary.gov.telemetry import get_bound_observability
             from mas.runtime.kernel.envelope import (
                 EnvelopeContext,
@@ -523,9 +512,7 @@ class KernelDriver:
                 direct.append(ret)
         if pool is None:
             if parallel_group_id is not None:
-                self._record_parallel_group_obs(
-                    ios, q, boundary="end", group_id=parallel_group_id
-                )
+                self._record_parallel_group_obs(ios, q, boundary="end", group_id=parallel_group_id)
             return direct
         results = pool.drain()
         out: list[IngressSymbol] = []
@@ -534,9 +521,7 @@ class KernelDriver:
             self._record_wait_state_obs(sym, q, boundary="end")
             out.append(ret)
         if parallel_group_id is not None:
-            self._record_parallel_group_obs(
-                ios, q, boundary="end", group_id=parallel_group_id
-            )
+            self._record_parallel_group_obs(ios, q, boundary="end", group_id=parallel_group_id)
         return out
 
     def _record_engine_return(
@@ -545,8 +530,8 @@ class KernelDriver:
         io: InvokeEngineIo,
         ret: IngressSymbol,
     ) -> None:
-        from mas.runtime.schema.ingress import EngineIoReturn
         from mas.runtime.engine.exchange_preview import format_llm_response
+        from mas.runtime.schema.ingress import EngineIoReturn
 
         if not isinstance(ret, EngineIoReturn):
             return

--- a/runtime/src/mas/runtime/kernel/egress_gate.py
+++ b/runtime/src/mas/runtime/kernel/egress_gate.py
@@ -5,13 +5,14 @@
 from __future__ import annotations
 
 from mas.runtime.boundary.gov.policy import EgressIntentView, apply_egress_modify
-from mas.runtime.kernel.config import KernelConfig
-from mas.runtime.kernel.envelope import (
-    EnvelopeContext,
-    contract_kind_for_op,
-    run_egress_authorize_envelope,
-)
 from mas.runtime.boundary.gov.telemetry import get_bound_observability
+from mas.runtime.kernel.config import KernelConfig
+from mas.runtime.kernel.control_pipeline import control_on_idle
+from mas.runtime.kernel.coord_hook import (
+    coord_after_egress_allowed,
+    coord_before_egress,
+    coord_on_egress_blocked,
+)
 from mas.runtime.kernel.coupling import (
     GovDecision,
     apply_control_engine_allow,
@@ -20,14 +21,25 @@ from mas.runtime.kernel.coupling import (
     apply_gov_terminate,
     enter_egress_chokepoint,
 )
-from mas.runtime.kernel.inflight import register_inflight
-from mas.runtime.kernel.control_pipeline import control_on_idle
-from mas.runtime.kernel.coord_hook import (
-    coord_after_egress_allowed,
-    coord_before_egress,
-    coord_on_egress_blocked,
-    coord_on_egress_hitl,
+from mas.runtime.kernel.envelope import (
+    EnvelopeContext,
+    contract_kind_for_op,
+    run_egress_authorize_envelope,
 )
+from mas.runtime.kernel.hitl_gate import emit_egress_hitl_pause
+from mas.runtime.kernel.inflight import register_inflight
+from mas.runtime.kernel.state import (
+    DpState,
+    QProduct,
+    RunEvent,
+    RunLedger,
+    ScheduledEgress,
+)
+from mas.runtime.kernel.types import InflightKind
+from mas.runtime.machines.memory import memory_on_egress_start
+from mas.runtime.machines.model import model_on_abort, model_on_egress
+from mas.runtime.machines.tool import tool_on_abort, tool_on_egress
+from mas.runtime.machines.transport import transport_on_egress
 from mas.runtime.schema.egress import (
     EgressSymbol,
     InvokeEngineIo,
@@ -36,19 +48,6 @@ from mas.runtime.schema.egress import (
 )
 from mas.runtime.schema.governance import GovernanceAction
 from mas.runtime.schema.hitl import HitlQuestionType, HitlResolveChoice
-from mas.runtime.kernel.hitl_gate import emit_egress_hitl_pause
-from mas.runtime.machines.context import ctx_on_abort
-from mas.runtime.machines.memory import memory_on_egress_start
-from mas.runtime.machines.model import model_on_abort, model_on_egress
-from mas.runtime.machines.tool import tool_on_abort, tool_on_egress
-from mas.runtime.machines.transport import transport_on_egress
-from mas.runtime.kernel.state import (
-    DpState,
-    QProduct,
-    ScheduledEgress,
-    RunLedger,
-    RunEvent,
-)
 
 
 def _destructive_for_op(op: ScheduledEgress, config: KernelConfig) -> bool:
@@ -228,7 +227,8 @@ def emit_scheduled_egress(
     view = apply_egress_modify(view, GovernanceAction(decision.value))
     q.hitl_gov_override = False
     _apply_engine_allow(q, view)
-    register_inflight(q, cid)
+    egress_kind: InflightKind = "MODEL" if view.op == "LLM_CALL" else "TOOL"
+    register_inflight(q, cid, kind=egress_kind, op=view.op)
     q.pending_engine_correlation_id = cid
     coord_after_egress_allowed(q)
 

--- a/runtime/src/mas/runtime/kernel/inflight.py
+++ b/runtime/src/mas/runtime/kernel/inflight.py
@@ -1,39 +1,41 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-"""Inflight engine I/O correlation tracking — parallel tool calls + stale discard."""
+"""Inflight engine I/O correlation tracking — backed by ``outbound_waits``."""
 
 from __future__ import annotations
 
+from mas.runtime.kernel.outbound_waits import (
+    clear_outbound_waits,
+    dismiss_outbound_wait,
+    is_outbound_pending,
+    pending_correlation_ids,
+    register_outbound_wait,
+)
 from mas.runtime.kernel.state import QProduct
+from mas.runtime.kernel.types import InflightKind, ScheduledEgress
 
 
-def register_inflight(q: QProduct, correlation_id: int) -> None:
-    if correlation_id <= 0:
-        return
-    if correlation_id not in q.inflight_correlation_ids:
-        q.inflight_correlation_ids.append(correlation_id)
+def register_inflight(
+    q: QProduct,
+    correlation_id: int,
+    *,
+    kind: InflightKind = "TOOL",
+    op: ScheduledEgress | str = "NONE",
+) -> None:
+    register_outbound_wait(q, correlation_id, kind=kind, op=op)
 
 
 def clear_inflight(q: QProduct) -> None:
-    q.inflight_correlation_ids.clear()
-    q.pending_engine_correlation_id = 0
+    clear_outbound_waits(q)
 
 
 def dismiss_inflight(q: QProduct, correlation_id: int) -> None:
-    q.inflight_correlation_ids = [c for c in q.inflight_correlation_ids if c != correlation_id]
-    if q.pending_engine_correlation_id == correlation_id:
-        q.pending_engine_correlation_id = 0
+    dismiss_outbound_wait(q, correlation_id)
 
 
 def is_inflight(q: QProduct, correlation_id: int) -> bool:
-    if q.inflight_correlation_ids:
-        return correlation_id in q.inflight_correlation_ids
-    return q.pending_engine_correlation_id > 0 and correlation_id == q.pending_engine_correlation_id
+    return is_outbound_pending(q, correlation_id)
 
 
 def pending_for_validate(q: QProduct) -> list[int]:
-    if q.inflight_correlation_ids:
-        return list(q.inflight_correlation_ids)
-    if q.pending_engine_correlation_id > 0:
-        return [q.pending_engine_correlation_id]
-    return []
+    return pending_correlation_ids(q)

--- a/runtime/src/mas/runtime/kernel/outbound_waits.py
+++ b/runtime/src/mas/runtime/kernel/outbound_waits.py
@@ -1,0 +1,75 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Unified ledger for outbound I/O the kernel is still waiting on."""
+
+from __future__ import annotations
+
+from mas.runtime.kernel.state import QProduct
+from mas.runtime.kernel.types import InflightKind, OutboundWait, ScheduledEgress
+
+
+def _sync_legacy_inflight_ids(q: QProduct) -> None:
+    q.inflight_correlation_ids = [w.correlation_id for w in q.outbound_waits]
+
+
+def register_outbound_wait(
+    q: QProduct,
+    correlation_id: int,
+    *,
+    kind: InflightKind,
+    op: ScheduledEgress | str = "NONE",
+) -> None:
+    if correlation_id <= 0:
+        return
+    wait = OutboundWait(correlation_id=correlation_id, kind=kind, op=op)
+    for index, existing in enumerate(q.outbound_waits):
+        if existing.correlation_id == correlation_id:
+            q.outbound_waits[index] = wait
+            _sync_legacy_inflight_ids(q)
+            return
+    q.outbound_waits.append(wait)
+    _sync_legacy_inflight_ids(q)
+
+
+def dismiss_outbound_wait(q: QProduct, correlation_id: int) -> None:
+    if correlation_id <= 0:
+        return
+    q.outbound_waits = [w for w in q.outbound_waits if w.correlation_id != correlation_id]
+    _sync_legacy_inflight_ids(q)
+    if q.pending_engine_correlation_id == correlation_id:
+        q.pending_engine_correlation_id = 0
+
+
+def clear_outbound_waits(q: QProduct) -> None:
+    q.outbound_waits.clear()
+    q.inflight_correlation_ids.clear()
+    q.pending_engine_correlation_id = 0
+
+
+def pending_outbound_waits(q: QProduct) -> list[OutboundWait]:
+    return list(q.outbound_waits)
+
+
+def pending_correlation_ids(q: QProduct) -> list[int]:
+    if q.outbound_waits:
+        return [w.correlation_id for w in q.outbound_waits]
+    if q.pending_engine_correlation_id > 0:
+        return [q.pending_engine_correlation_id]
+    return list(q.inflight_correlation_ids)
+
+
+def has_pending_outbound(q: QProduct, *, kind: InflightKind | None = None) -> bool:
+    waits = q.outbound_waits
+    if not waits and q.pending_engine_correlation_id > 0:
+        return kind in (None, "MODEL")
+    if kind is None:
+        return bool(waits) or q.pending_engine_correlation_id > 0
+    return any(w.kind == kind for w in waits)
+
+
+def is_outbound_pending(q: QProduct, correlation_id: int) -> bool:
+    if correlation_id <= 0:
+        return False
+    if any(w.correlation_id == correlation_id for w in q.outbound_waits):
+        return True
+    return q.pending_engine_correlation_id > 0 and correlation_id == q.pending_engine_correlation_id

--- a/runtime/src/mas/runtime/kernel/parallel_tools.py
+++ b/runtime/src/mas/runtime/kernel/parallel_tools.py
@@ -9,9 +9,9 @@ from mas.runtime.kernel.config import KernelConfig
 from mas.runtime.kernel.coupling import apply_control_tool_request
 from mas.runtime.kernel.egress_gate import emit_scheduled_egress, schedule_tool_egress
 from mas.runtime.kernel.inflight import register_inflight
+from mas.runtime.kernel.state import DpState, QProduct, RunLedger
 from mas.runtime.schema.egress import EgressSymbol, EmitHitlRequest, InvokeEngineIo, RaiseBoundaryError
 from mas.runtime.schema.ingress import ToolCallSpec
-from mas.runtime.kernel.state import DpState, QProduct, RunLedger
 
 
 def schedule_parallel_tools_egress(
@@ -49,7 +49,7 @@ def schedule_parallel_tools_egress(
             return batch
         for sym in batch:
             if isinstance(sym, InvokeEngineIo) and sym.op == "TOOL_CALL":
-                register_inflight(q, sym.correlation_id)
+                register_inflight(q, sym.correlation_id, kind="TOOL", op="TOOL_CALL")
                 q.pending_tools_by_cid[sym.correlation_id] = (
                     spec.tool_name,
                     dict(spec.tool_arguments),

--- a/runtime/src/mas/runtime/kernel/state.py
+++ b/runtime/src/mas/runtime/kernel/state.py
@@ -14,6 +14,7 @@ from mas.runtime.kernel.types import (
     LifecycleState,
     MemoryState,
     ModelState,
+    OutboundWait,
     ScheduledEgress,
     SessionState,
     ToolState,
@@ -30,6 +31,7 @@ __all__ = [
     "LifecycleState",
     "MemoryState",
     "ModelState",
+    "OutboundWait",
     "QProduct",
     "RunEvent",
     "RunLedger",
@@ -118,6 +120,7 @@ class QProduct:
     pending_ingress_return: dict = field(default_factory=dict)
     control_phase: str = "IDLE"
     pending_engine_correlation_id: int = 0
+    outbound_waits: list[OutboundWait] = field(default_factory=list)
     inflight_correlation_ids: list[int] = field(default_factory=list)
     pending_tool_name: str = ""
     pending_tool_args: dict = field(default_factory=dict)

--- a/runtime/src/mas/runtime/kernel/state_serialize.py
+++ b/runtime/src/mas/runtime/kernel/state_serialize.py
@@ -11,12 +11,13 @@ from mas.runtime.kernel.state import (
     MemoryState,
     ModelState,
     QProduct,
-    SessionState,
-    RunLedger,
     RunEvent,
+    RunLedger,
+    SessionState,
     ToolState,
     TransportState,
 )
+from mas.runtime.kernel.types import OutboundWait
 
 
 def q_product_to_dict(q: QProduct) -> dict:
@@ -45,6 +46,10 @@ def q_product_to_dict(q: QProduct) -> dict:
         "hitl_tools_approved_turn": q.hitl_tools_approved_turn,
         "control_phase": q.control_phase,
         "pending_engine_correlation_id": q.pending_engine_correlation_id,
+        "outbound_waits": [
+            {"correlation_id": w.correlation_id, "kind": w.kind, "op": w.op}
+            for w in q.outbound_waits
+        ],
         "inflight_correlation_ids": list(q.inflight_correlation_ids),
         "pending_tool_name": q.pending_tool_name,
         "pending_tool_args": dict(q.pending_tool_args),
@@ -91,6 +96,14 @@ def q_product_from_dict(data: dict) -> QProduct:
         hitl_tools_approved_turn=bool(data.get("hitl_tools_approved_turn", False)),
         control_phase=data.get("control_phase", "IDLE"),
         pending_engine_correlation_id=int(data.get("pending_engine_correlation_id", 0)),
+        outbound_waits=[
+            OutboundWait(
+                correlation_id=int(row["correlation_id"]),
+                kind=row.get("kind", "TOOL"),
+                op=row.get("op", "NONE"),
+            )
+            for row in (data.get("outbound_waits") or [])
+        ],
         inflight_correlation_ids=[
             int(x) for x in (data.get("inflight_correlation_ids") or [])
         ],

--- a/runtime/src/mas/runtime/kernel/types.py
+++ b/runtime/src/mas/runtime/kernel/types.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from typing import Literal
+
 
 class LifecycleState(str, Enum):
     RUNNING = "RUNNING"
@@ -72,5 +74,14 @@ class GovState(str, Enum):
     BLOCKED = "BLOCKED"
 
 
-InflightKind = Literal["NONE", "MODEL", "TOOL"]
+InflightKind = Literal["NONE", "MODEL", "TOOL", "HITL"]
 ScheduledEgress = Literal["NONE", "LLM_CALL", "TOOL_CALL", "MEMORY_OP", "TRANSPORT_MSG"]
+
+
+@dataclass(frozen=True)
+class OutboundWait:
+    """One external call the runtime has dispatched but not yet resolved."""
+
+    correlation_id: int
+    kind: InflightKind
+    op: ScheduledEgress | str = "NONE"

--- a/runtime/src/mas/runtime/machines/gov.py
+++ b/runtime/src/mas/runtime/machines/gov.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from mas.runtime.kernel.outbound_waits import dismiss_outbound_wait, register_outbound_wait
 from mas.runtime.kernel.state import QProduct, ScheduledEgress
 from mas.runtime.kernel.types import GovState
 
@@ -23,9 +24,12 @@ def gov_enter_hitl_pending(
     q.hitl_request_id = request_id
     q.hitl_pending_schedule = pending_schedule
     q.hitl_question_type = question_type
+    register_outbound_wait(q, request_id, kind="HITL", op=pending_schedule)
 
 
 def gov_clear_hitl(q: QProduct) -> None:
+    if q.hitl_request_id > 0:
+        dismiss_outbound_wait(q, q.hitl_request_id)
     q.hitl_request_id = 0
     q.hitl_pending_schedule = "NONE"
     q.hitl_question_type = ""

--- a/runtime/tests/test_outbound_wait_assembly.py
+++ b/runtime/tests/test_outbound_wait_assembly.py
@@ -1,0 +1,196 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Assembly boundary: provider-safe history + structurally pinned working memory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mas.library.standard.plugins.context.assembler import ContextAssemblerPlugin
+from mas.library.standard.plugins.context.conversation import StackConversation
+from mas.library.standard.plugins.context.provider_payload import assert_provider_payload
+from mas.runtime.boundary.context.assemble import assemble_llm_messages
+from mas.runtime.driver.mocks import AutoCtxAssembler
+from mas.runtime.kernel.inflight import register_inflight
+from mas.runtime.kernel.outbound_waits import pending_outbound_waits
+from mas.runtime.kernel.state import QProduct
+
+
+def _committed_tool_turn(call_id: str, answer: str) -> list[dict[str, Any]]:
+    return [
+        {"role": "user", "content": f"question-{call_id}"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": call_id, "function": {"name": "search", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": f"result-{call_id}"},
+        {"role": "assistant", "content": answer},
+    ]
+
+
+def test_plain_turn_history_unchanged() -> None:
+    ctx = AutoCtxAssembler(last_user_text="Follow-up?")
+    ctx.turn_history = [("Q1?", "A1."), ("Q2?", "A2.")]
+    messages = assemble_llm_messages(ctx)
+    assert [m["role"] for m in messages] == ["user", "assistant", "user", "assistant", "user"]
+    assert messages[-1]["content"] == "Follow-up?"
+
+
+def test_working_memory_pinned_whole_in_turn() -> None:
+    q = QProduct()
+    register_inflight(q, 7, kind="TOOL", op="TOOL_CALL")
+    ctx = AutoCtxAssembler(last_user_text="continue")
+    ctx.q_product = q
+    ctx.record_assistant_tool_call(call_id="call_7", tool_name="search", arguments={})
+    ctx.record_tool_result(call_id="call_7", content="partial")
+    ctx.record_assistant_tool_call(call_id="call_8", tool_name="search", arguments={})
+
+    assert len(ctx.working_memory.messages) == 3
+    assert pending_outbound_waits(q)[0].kind == "TOOL"
+
+
+def test_assemble_pins_wm_under_budget() -> None:
+    q = QProduct()
+    register_inflight(q, 1, kind="TOOL", op="TOOL_CALL")
+    ctx = AutoCtxAssembler(last_user_text="Who is POTUS?")
+    ctx.q_product = q
+    ctx.record_assistant_tool_call(call_id="call_1", tool_name="web-search", arguments={"q": "POTUS"})
+    ctx.record_tool_result(call_id="call_1", content="Donald Trump is president.")
+    manifest = {
+        "spec": {
+            "context_manager": {"type": "stack"},
+            "token_budget": 50,
+            "reserve_tokens": 0,
+        }
+    }
+    messages = assemble_llm_messages(ctx, manifest=manifest)
+    assert messages[-1]["role"] == "tool"
+    assert_provider_payload(messages)
+
+
+def test_assemble_committed_history_provider_safe_after_stack_trim() -> None:
+    committed: list[dict[str, Any]] = []
+    for i in range(8):
+        committed.extend(_committed_tool_turn(f"call_{i}", f"answer-{i}"))
+    ctx = AutoCtxAssembler(last_user_text="What next?", committed_messages=committed)
+    manifest = {
+        "spec": {
+            "context_manager": {"type": "stack", "params": {"max_messages": 6}},
+            "token_budget": 500_000,
+        }
+    }
+    messages = assemble_llm_messages(ctx, manifest=manifest)
+    assert messages[-1]["content"] == "What next?"
+    assert_provider_payload(messages)
+
+
+def test_inflight_partial_parallel_tools_preserved_in_payload() -> None:
+    q = QProduct()
+    register_inflight(q, 10, kind="TOOL", op="TOOL_CALL")
+    register_inflight(q, 11, kind="TOOL", op="TOOL_CALL")
+    ctx = AutoCtxAssembler(last_user_text="continue")
+    ctx.q_product = q
+    ctx.working_memory.record_assistant_tool_calls(
+        [
+            ("call_a", "search", {"q": "a"}),
+            ("call_b", "search", {"q": "b"}),
+        ]
+    )
+    ctx.working_memory.record_tool_result(call_id="call_a", content="result-a")
+    messages = assemble_llm_messages(ctx)
+    assert messages[-1]["tool_call_id"] == "call_a"
+    assert len(messages[-2]["tool_calls"]) == 2
+
+
+def test_multi_turn_committed_tool_visible_on_follow_up() -> None:
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("Who is POTUS?")
+    ctx.record_assistant_tool_call(call_id="call_1", tool_name="web-search", arguments={"q": "POTUS"})
+    ctx.record_tool_result(call_id="call_1", content="Donald Trump")
+    ctx.note_agent_response("Donald Trump is POTUS.")
+    ctx.note_user_input("Who was before?")
+    messages = assemble_llm_messages(ctx)
+    assert any(m.get("role") == "tool" for m in messages)
+    assert messages[-1]["content"] == "Who was before?"
+
+
+def test_hitl_style_mismatched_ids_rebound_in_assembly() -> None:
+    ctx = AutoCtxAssembler(
+        last_user_text="Follow-up?",
+        committed_messages=[
+            {"role": "user", "content": "Who is POTUS?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "search", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_3", "content": "Maxence Postu is POTUS"},
+        ],
+    )
+    messages = assemble_llm_messages(ctx)
+    assert any("Maxence Postu is POTUS" in str(m.get("content")) for m in messages)
+    assert_provider_payload(messages)
+
+
+def test_assembler_plugin_retains_tool_messages() -> None:
+    plugin = ContextAssemblerPlugin(conversation_strategy=StackConversation(max_messages=4))
+    messages = _committed_tool_turn("call_0", "a0") + _committed_tool_turn("call_1", "a1")
+    messages.append({"role": "user", "content": "current"})
+    out = plugin._apply_conversation_strategy(messages)
+    assert any(m.get("role") == "tool" for m in out)
+    assert_provider_payload(out)
+
+
+def test_assembler_preserves_live_turn_inflight_tool_calls() -> None:
+    plugin = ContextAssemblerPlugin(conversation_strategy=StackConversation(max_messages=4))
+    messages = _committed_tool_turn("call_0", "a0") + [
+        {"role": "user", "content": "current"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_live", "function": {"name": "search", "arguments": "{}"}}],
+        },
+    ]
+    out = plugin._apply_conversation_strategy(messages)
+    live = [m for m in out if m.get("tool_calls")]
+    assert any(c["id"] == "call_live" for m in live for c in m["tool_calls"])
+    assert_provider_payload(out)
+
+
+def test_high_level_react_path_still_sees_tool_result() -> None:
+    ctx = AutoCtxAssembler(last_user_text="Who is POTUS?")
+    q = QProduct()
+    register_inflight(q, 1, kind="TOOL", op="TOOL_CALL")
+    ctx.q_product = q
+    ctx.record_assistant_tool_call(call_id="call_1", tool_name="web-search", arguments={"q": "POTUS"})
+    ctx.record_tool_result(call_id="call_1", content="Donald Trump is president.")
+    messages = assemble_llm_messages(ctx)
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["content"] == "Donald Trump is president."
+
+
+def test_concurrent_sessions_have_isolated_kernel_and_assembly() -> None:
+    """Each session owns its own kernel state and context; outbound waits do not cross sessions."""
+    q_a = QProduct()
+    q_b = QProduct()
+    register_inflight(q_a, 1, kind="TOOL", op="TOOL_CALL")
+
+    ctx_a = AutoCtxAssembler(session_id="sess-a", last_user_text="A")
+    ctx_a.q_product = q_a
+    ctx_a.record_assistant_tool_call(call_id="call_a", tool_name="search", arguments={})
+    ctx_a.record_tool_result(call_id="call_a", content="result-a")
+
+    ctx_b = AutoCtxAssembler(session_id="sess-b", last_user_text="B")
+    ctx_b.q_product = q_b
+
+    msgs_a = assemble_llm_messages(ctx_a)
+    msgs_b = assemble_llm_messages(ctx_b)
+
+    assert pending_outbound_waits(q_a)
+    assert not pending_outbound_waits(q_b)
+    assert any(m.get("role") == "tool" for m in msgs_a)
+    assert msgs_b[-1]["content"] == "B"
+    assert not any(m.get("role") == "tool" for m in msgs_b)
+    assert_provider_payload(msgs_a)
+    assert_provider_payload(msgs_b)

--- a/runtime/tests/test_outbound_waits.py
+++ b/runtime/tests/test_outbound_waits.py
@@ -1,0 +1,62 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Kernel outbound-wait ledger."""
+
+from __future__ import annotations
+
+from mas.runtime.kernel.inflight import (
+    clear_inflight,
+    dismiss_inflight,
+    is_inflight,
+    pending_for_validate,
+    register_inflight,
+)
+from mas.runtime.kernel.outbound_waits import (
+    has_pending_outbound,
+    pending_outbound_waits,
+    register_outbound_wait,
+)
+from mas.runtime.kernel.state import QProduct
+
+
+def test_register_and_dismiss_model_wait() -> None:
+    q = QProduct()
+    register_outbound_wait(q, 3, kind="MODEL", op="LLM_CALL")
+    assert has_pending_outbound(q, kind="MODEL")
+    assert pending_for_validate(q) == [3]
+    assert is_inflight(q, 3)
+    dismiss_inflight(q, 3)
+    assert not has_pending_outbound(q)
+    assert pending_for_validate(q) == []
+
+
+def test_parallel_tool_waits_tracked_together() -> None:
+    q = QProduct()
+    register_inflight(q, 4, kind="TOOL", op="TOOL_CALL")
+    register_inflight(q, 5, kind="TOOL", op="TOOL_CALL")
+    assert pending_for_validate(q) == [4, 5]
+    dismiss_inflight(q, 4)
+    assert pending_for_validate(q) == [5]
+    assert has_pending_outbound(q, kind="TOOL")
+
+
+def test_hitl_wait_registers_on_gov_hold() -> None:
+    from mas.runtime.machines.gov import gov_clear_hitl, gov_enter_hitl_pending
+
+    q = QProduct()
+    gov_enter_hitl_pending(q, request_id=9, pending_schedule="TOOL_CALL")
+    waits = pending_outbound_waits(q)
+    assert len(waits) == 1
+    assert waits[0].kind == "HITL"
+    assert waits[0].op == "TOOL_CALL"
+    gov_clear_hitl(q)
+    assert not has_pending_outbound(q, kind="HITL")
+
+
+def test_clear_inflight_clears_ledger() -> None:
+    q = QProduct()
+    register_inflight(q, 1, kind="MODEL", op="LLM_CALL")
+    register_inflight(q, 2, kind="TOOL", op="TOOL_CALL")
+    clear_inflight(q)
+    assert q.outbound_waits == []
+    assert q.inflight_correlation_ids == []


### PR DESCRIPTION
## Problem

When conversation history is trimmed (`max_messages`, sliding window, or token budget), cuts can land between an assistant tool-call message and its tool result. Bedrock and similar APIs reject that payload.

Supersedes #55 with a different layering: repair at assembly instead of shape-aware trimmers.

## Changes

- Repair committed history at assembly via `sanitize_provider_messages`
- Pin in-turn working memory with token-budget `pin_tail`
- Add per-session kernel outbound-waits ledger (MODEL / TOOL / HITL)
- Fix assembler to retain `tool` messages and skip live-turn sanitize
- Fix pre-existing `driver.py` lint; add `AGENTS.md` zero-tolerance rule for open failures

## Rationale

1. Trimming strategies stay position-based — no tool-shape coupling.
2. Provider invariants enforced once at the assembly boundary.
3. In-turn working memory is never split by token budget mid-ReAct.
4. Regression tests cover PR #55 failure modes (stack orphans, sliding splits, token budgets).

## Test plan

- [x] `library-standard/tests/test_provider_payload.py` (PR #55 regressions)
- [x] `runtime/tests/test_outbound_waits.py`
- [x] `runtime/tests/test_outbound_wait_assembly.py`
- [x] `task verify`

Tracking: cisco-eti/ioc-core-mas-lab#46