### PR TITLE
feat(context): commit-time conversation chunk graph with rolling summary

### DIFF
--- a/ctl/src/mas/ctl/session/bootstrap.py
+++ b/ctl/src/mas/ctl/session/bootstrap.py
@@ -4,14 +4,11 @@
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-
-from mas.runtime.driver.instance import RuntimeInstance
-from mas.runtime.driver.mocks import AutoCtxAssembler
 
 from mas.ctl.adapters.checkpoint import JsonCheckpointStore
 from mas.ctl.adapters.memory_seed import (
@@ -26,6 +23,8 @@ from mas.ctl.validate import validate_file, validation_enabled
 from mas.ctl.workspace.config import WorkspaceConfig
 from mas.runtime.agent_defaults import default_pattern_plugin_id
 from mas.runtime.boundary.context.manifest_context import context_chunks_from_spec
+from mas.runtime.driver.instance import RuntimeInstance
+from mas.runtime.driver.mocks import AutoCtxAssembler
 
 logger = logging.getLogger(__name__)
 
@@ -155,9 +154,11 @@ def instantiate_runtime(
 
     from mas.runtime.boundary.context.working_memory_compaction import (
         apply_working_memory_compaction,
+        working_memory_compaction_runtime,
     )
 
     apply_working_memory_compaction(spec, engine=selection.engine)
+    ctx.working_memory_compaction = working_memory_compaction_runtime(spec)
     if "context_manager" in spec and options.agent_manifest is not None:
         # LiveLlmEngine holds a live reference to options.agent_manifest (not
         # `spec` above, a separate shallow copy) and reads context_manager

--- a/ctl/tests/test_working_memory_compaction_bootstrap.py
+++ b/ctl/tests/test_working_memory_compaction_bootstrap.py
@@ -61,8 +61,8 @@ def test_no_working_memory_compaction_leaves_context_manager_absent(tmp_path: Pa
 
 def test_summarize_wires_a_real_summarize_fn_off_the_resolved_engine(tmp_path: Path, monkeypatch):
     """standard:mock-llm still resolves to a LiveLlmEngine (pointed at a fake
-    endpoint, not a SimulatedEngine) -- it has the completion primitives
-    build_llm_summarize_fn needs, so summarize wires a real callable rather
+    endpoint, not a SimulatedEngine) -- it implements CompactionSummarizeEngine,
+    so summarize wires a real callable rather
     than degrading. The degrade-to-keep_recent path (no completion
     primitives available at all) is covered at the facade level in
     test_working_memory_compaction.py."""

--- a/runtime/src/mas/runtime/boundary/context/__init__.py
+++ b/runtime/src/mas/runtime/boundary/context/__init__.py
@@ -4,20 +4,13 @@
 
 from mas.runtime.boundary.context.assemble import assemble_llm_messages
 from mas.runtime.boundary.context.trim import context_manager_spec
-from mas.runtime.boundary.context.working_memory import (
-    SOURCE_TYPE,
-    WorkingMemoryContextSource,
-    WorkingMemoryStore,
-    working_memory_source,
-)
+from mas.runtime.boundary.context.working_memory import SOURCE_TYPE, WorkingMemoryStore
 from mas.runtime.contracts.cm_factory import CMFactory
 
 __all__ = [
     "SOURCE_TYPE",
     "CMFactory",
-    "WorkingMemoryContextSource",
     "WorkingMemoryStore",
     "assemble_llm_messages",
     "context_manager_spec",
-    "working_memory_source",
 ]

--- a/runtime/src/mas/runtime/boundary/context/assemble.py
+++ b/runtime/src/mas/runtime/boundary/context/assemble.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any
 
 from mas.library.standard.plugins.context.provider_payload import sanitize_provider_messages
+from mas.runtime.boundary.context.conversation_chunks import ConversationChunkStore
 from mas.runtime.boundary.context.trim import context_manager_spec
 from mas.runtime.boundary.context.working_memory import WorkingMemoryStore
 from mas.runtime.contracts.cm_factory import CMFactory
@@ -63,8 +64,13 @@ def assemble_llm_messages(
     if system_parts:
         messages.append({"role": "system", "content": "\n\n".join(system_parts)})
 
+    chunk_store = getattr(ctx, "conversation_chunks", None)
     committed = list(getattr(ctx, "committed_messages", []) or [])
-    if committed:
+    if isinstance(chunk_store, ConversationChunkStore) and (
+        chunk_store.order or chunk_store.summary_chunk_id
+    ):
+        past = chunk_store.project_messages()
+    elif committed:
         past = list(committed)
     else:
         past = _turn_history_to_past(list(getattr(ctx, "turn_history", []) or []))

--- a/runtime/src/mas/runtime/boundary/context/chunk_compaction.py
+++ b/runtime/src/mas/runtime/boundary/context/chunk_compaction.py
@@ -1,0 +1,22 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Commit-time chunk compaction — runs after turn commit, not on every assembly."""
+
+from __future__ import annotations
+
+from mas.runtime.boundary.context.conversation_chunks import ConversationChunkStore
+from mas.runtime.boundary.context.working_memory_compaction import WorkingMemoryCompactionRuntime
+
+
+def maybe_compact_chunks_after_commit(
+    store: ConversationChunkStore,
+    *,
+    compaction: WorkingMemoryCompactionRuntime | None,
+) -> bool:
+    if compaction is None:
+        return False
+    return store.maybe_compact(
+        summary_threshold=compaction.summary_threshold,
+        keep_message_chunks=compaction.keep_turns,
+        summarize_fn=compaction.summarize_fn,
+    )

--- a/runtime/src/mas/runtime/boundary/context/conversation_chunks.py
+++ b/runtime/src/mas/runtime/boundary/context/conversation_chunks.py
@@ -1,0 +1,198 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Commit-time conversation chunks — summaries retain children for audit/replay."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from uuid import uuid4
+
+ChunkKind = Literal["messages", "summary"]
+
+
+def _estimate_tokens(messages: list[dict[str, Any]]) -> int:
+    total = 0
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            total += len(content)
+        for call in msg.get("tool_calls") or []:
+            fn = call.get("function") or {}
+            total += len(str(fn.get("name", ""))) + len(str(fn.get("arguments", "")))
+    return total // 4 + len(messages) * 4
+
+
+def _new_chunk_id() -> str:
+    return f"chunk_{uuid4().hex[:12]}"
+
+
+@dataclass
+class MessageChunk:
+    chunk_id: str
+    messages: list[dict[str, Any]]
+    kind: ChunkKind = "messages"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chunk_id": self.chunk_id,
+            "kind": self.kind,
+            "messages": list(self.messages),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MessageChunk:
+        return cls(
+            chunk_id=str(data["chunk_id"]),
+            messages=list(data.get("messages") or []),
+        )
+
+
+@dataclass
+class SummaryChunk:
+    chunk_id: str
+    text: str
+    child_chunk_ids: list[str]
+    kind: ChunkKind = "summary"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chunk_id": self.chunk_id,
+            "kind": self.kind,
+            "text": self.text,
+            "child_chunk_ids": list(self.child_chunk_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SummaryChunk:
+        return cls(
+            chunk_id=str(data["chunk_id"]),
+            text=str(data.get("text") or ""),
+            child_chunk_ids=[str(x) for x in data.get("child_chunk_ids") or []],
+        )
+
+
+Chunk = MessageChunk | SummaryChunk
+
+
+@dataclass
+class ConversationChunkStore:
+    """Durable turn chunks with optional rolling summary (children kept for traceability)."""
+
+    chunks: dict[str, Chunk] = field(default_factory=dict)
+    order: list[str] = field(default_factory=list)
+    summary_chunk_id: str = ""
+
+    def append_turn(self, messages: list[dict[str, Any]]) -> str:
+        if not messages:
+            return ""
+        chunk = MessageChunk(chunk_id=_new_chunk_id(), messages=list(messages))
+        self.chunks[chunk.chunk_id] = chunk
+        self.order.append(chunk.chunk_id)
+        return chunk.chunk_id
+
+    def project_messages(self) -> list[dict[str, Any]]:
+        """Linear OpenAI-shaped list for LLM assembly (summary block + recent chunks)."""
+        out: list[dict[str, Any]] = []
+        if self.summary_chunk_id:
+            summary = self.chunks.get(self.summary_chunk_id)
+            if isinstance(summary, SummaryChunk) and summary.text.strip():
+                out.append(
+                    {
+                        "role": "system",
+                        "content": f"[Conversation summary — {len(summary.child_chunk_ids)} chunk(s)]\n{summary.text}",
+                    }
+                )
+        for chunk_id in self.order:
+            chunk = self.chunks.get(chunk_id)
+            if isinstance(chunk, MessageChunk):
+                out.extend(chunk.messages)
+        return out
+
+    def messages_for_chunk_ids(self, chunk_ids: list[str]) -> list[dict[str, Any]]:
+        msgs: list[dict[str, Any]] = []
+        for chunk_id in chunk_ids:
+            chunk = self.chunks.get(chunk_id)
+            if isinstance(chunk, MessageChunk):
+                msgs.extend(chunk.messages)
+        return msgs
+
+    def maybe_compact(
+        self,
+        *,
+        summary_threshold: int,
+        keep_message_chunks: int,
+        summarize_fn: Callable[[list[dict[str, Any]]], str],
+    ) -> bool:
+        """Fold oldest message chunks into the rolling summary (incremental, children retained)."""
+        if summary_threshold <= 0 or keep_message_chunks < 0:
+            return False
+        projected = self.project_messages()
+        if _estimate_tokens(projected) <= summary_threshold:
+            return False
+        message_ids = [cid for cid in self.order if isinstance(self.chunks.get(cid), MessageChunk)]
+        if len(message_ids) <= keep_message_chunks:
+            return False
+
+        to_fold = message_ids[: len(message_ids) - keep_message_chunks]
+        if not to_fold:
+            return False
+
+        fold_messages = self.messages_for_chunk_ids(to_fold)
+        if not fold_messages:
+            return False
+
+        if self.summary_chunk_id:
+            prior = self.chunks[self.summary_chunk_id]
+            if isinstance(prior, SummaryChunk):
+                incremental_input = [
+                    {"role": "system", "content": f"[Prior summary]\n{prior.text}"},
+                    *fold_messages,
+                ]
+                new_text = summarize_fn(incremental_input)
+                child_ids = list(prior.child_chunk_ids) + to_fold
+                prior.text = new_text.strip()
+                prior.child_chunk_ids = child_ids
+            else:
+                new_text = summarize_fn(fold_messages)
+                self.summary_chunk_id = _new_chunk_id()
+                self.chunks[self.summary_chunk_id] = SummaryChunk(
+                    chunk_id=self.summary_chunk_id,
+                    text=new_text.strip(),
+                    child_chunk_ids=to_fold,
+                )
+        else:
+            new_text = summarize_fn(fold_messages)
+            self.summary_chunk_id = _new_chunk_id()
+            self.chunks[self.summary_chunk_id] = SummaryChunk(
+                chunk_id=self.summary_chunk_id,
+                text=new_text.strip(),
+                child_chunk_ids=to_fold,
+            )
+
+        self.order = [cid for cid in self.order if cid not in to_fold]
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summary_chunk_id": self.summary_chunk_id,
+            "order": list(self.order),
+            "chunks": {cid: chunk.to_dict() for cid, chunk in self.chunks.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ConversationChunkStore:
+        if not data:
+            return cls()
+        store = cls(
+            summary_chunk_id=str(data.get("summary_chunk_id") or ""),
+            order=[str(x) for x in data.get("order") or []],
+        )
+        for cid, raw in (data.get("chunks") or {}).items():
+            kind = raw.get("kind", "messages")
+            if kind == "summary":
+                store.chunks[str(cid)] = SummaryChunk.from_dict(raw)
+            else:
+                store.chunks[str(cid)] = MessageChunk.from_dict(raw)
+        return store

--- a/runtime/src/mas/runtime/boundary/context/dp_inject.py
+++ b/runtime/src/mas/runtime/boundary/context/dp_inject.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-from mas.runtime.registry import get_registry
 from mas.runtime.kernel.state import QProduct
+from mas.runtime.registry import get_registry
 
 
 def inject_dp_protocol(

--- a/runtime/src/mas/runtime/boundary/context/trim.py
+++ b/runtime/src/mas/runtime/boundary/context/trim.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 
 from typing import Any
 
+CONTEXT_MANAGER_TYPE_SUMMARISING = "summarising"
+
+
+def is_summarising_context_manager(cm: dict[str, Any] | None) -> bool:
+    return isinstance(cm, dict) and cm.get("type") == CONTEXT_MANAGER_TYPE_SUMMARISING
+
 
 def context_manager_spec(manifest: dict | None) -> dict[str, Any]:
     spec = (manifest or {}).get("spec") or {}

--- a/runtime/src/mas/runtime/boundary/context/working_memory.py
+++ b/runtime/src/mas/runtime/boundary/context/working_memory.py
@@ -8,22 +8,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-from mas.runtime.boundary.context.trim import context_manager_spec
-
 SOURCE_TYPE = "working_memory"
-
-
-def _slice_limit(manifest: dict | None) -> int:
-    cm = context_manager_spec(manifest)
-    params = cm.get("params") or {}
-    for key in ("working_memory_messages", "max_in_turn_messages", "max_messages"):
-        raw = params.get(key)
-        if raw is not None:
-            try:
-                return max(0, int(raw))
-            except (TypeError, ValueError):
-                break
-    return 20
 
 
 @dataclass
@@ -98,24 +83,3 @@ class WorkingMemoryStore:
     def record_assistant_message(self, content: str) -> None:
         if content.strip():
             self.messages.append({"role": "assistant", "content": content})
-
-
-@dataclass(frozen=True)
-class WorkingMemoryContextSource:
-    """Queried by context manager — not generic L2 memory / RAG."""
-
-    store: WorkingMemoryStore
-    source_type: str = SOURCE_TYPE
-    mechanism: str = "inject"
-
-    def collect_context(self, *, manifest: dict | None = None, **_: Any) -> list[dict[str, Any]]:
-        limit = _slice_limit(manifest)
-        if limit <= 0 or not self.store.messages:
-            return []
-        msgs = self.store.messages
-        start = max(0, len(msgs) - limit)
-        return list(msgs[start:])
-
-
-def working_memory_source(store: WorkingMemoryStore) -> WorkingMemoryContextSource:
-    return WorkingMemoryContextSource(store=store)

--- a/runtime/src/mas/runtime/boundary/context/working_memory_compaction.py
+++ b/runtime/src/mas/runtime/boundary/context/working_memory_compaction.py
@@ -12,11 +12,16 @@ See ``docs/design/working-memory-compaction.md``.
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
+
+from mas.runtime.boundary.context.trim import (
+    CONTEXT_MANAGER_TYPE_SUMMARISING,
+    is_summarising_context_manager,
+)
+from mas.runtime.engine.protocol import CompactionSummarizeEngine
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +31,7 @@ logger = logging.getLogger(__name__)
 _STRATEGY_TO_CM_TYPE: dict[str, str] = {
     "keep_recent": "stack",
     "sliding_window": "sliding_window",
-    "summarize": "summarising",
+    "summarize": CONTEXT_MANAGER_TYPE_SUMMARISING,
 }
 
 # Which compaction sub-keys become which context_manager param, per strategy.
@@ -41,6 +46,45 @@ SUMMARIZE_INSTRUCTIONS = (
     "facts, decisions, and any identifiers (names, IDs, numbers) a later "
     "turn might need to reference. Write plain prose, not a transcript."
 )
+
+
+@dataclass(frozen=True)
+class WorkingMemoryCompactionRuntime:
+    """Commit-time compaction of the cross-turn working-memory buffer.
+
+    Manifest authors set ``spec.working_memory.compaction`` (or an explicit
+    ``summarising`` ``context_manager``). ``summarize_fn`` is engine wiring —
+    not a manifest field — and belongs on working memory, not on the context
+    manager plugin surface (``ContextManagerContract`` shapes history at
+    assembly; it is not a context source).
+    """
+
+    summary_threshold: int
+    keep_turns: int
+    summarize_fn: Callable[[list[dict[str, Any]]], str]
+
+
+def working_memory_compaction_runtime(spec: dict[str, Any]) -> WorkingMemoryCompactionRuntime | None:
+    """Resolved commit-time compaction after ``apply_working_memory_compaction``."""
+    cm = spec.get("context_manager")
+    if not isinstance(cm, dict) or not is_summarising_context_manager(cm):
+        return None
+    params = cm.get("params") or {}
+    summarize_fn = params.get("summarize_fn")
+    if not callable(summarize_fn):
+        return None
+    try:
+        raw_threshold = params.get("summary_threshold")
+        raw_keep = params.get("keep_turns")
+        threshold = int(raw_threshold) if raw_threshold is not None else 4000
+        keep = int(raw_keep) if raw_keep is not None else 10
+    except (TypeError, ValueError):
+        return None
+    return WorkingMemoryCompactionRuntime(
+        summary_threshold=threshold,
+        keep_turns=keep,
+        summarize_fn=summarize_fn,
+    )
 
 
 def context_manager_binding_from_compaction(compaction: dict[str, Any]) -> dict[str, Any]:
@@ -77,66 +121,44 @@ def resolve_working_memory_context_manager(spec: dict[str, Any]) -> dict[str, An
     return context_manager_binding_from_compaction(compaction)
 
 
-def build_llm_summarize_fn(engine: Any) -> Callable[[list[dict[str, Any]]], str]:
-    """A ``SummarizingConversation``-compatible ``summarize_fn`` backed by
-    ``engine``'s own configured model -- no separate model-selection surface.
+def build_llm_summarize_fn(engine: CompactionSummarizeEngine) -> Callable[[list[dict[str, Any]]], str]:
+    """Return ``engine.summarize_messages`` for ``SummarizingConversation`` wiring."""
+    if not isinstance(engine, CompactionSummarizeEngine):
+        raise TypeError(f"{type(engine).__name__} does not implement CompactionSummarizeEngine")
+    return engine.summarize_messages
 
-    Reuses ``LiveLlmEngine``'s existing completion primitives
-    (``_model_access_chat``/``_chat_completion``) rather than the full
-    ``InvokeEngineIo``/kernel turn machinery, since this is a one-off,
-    out-of-band call made during context assembly, not a tracked turn. It
-    still goes through the engine's own ``BudgetTracker`` (``allow_llm``/
-    ``note_llm``) so a manifest's ``spec.budget.max_llm_calls`` ceiling can't
-    be silently exceeded by summarization calls the budget never sees.
-    """
 
-    def summarize_fn(messages: list[dict[str, Any]]) -> str:
-        budget = getattr(engine, "_budget", None)
-        if budget is not None and not budget.allow_llm():
-            raise RuntimeError(
-                "working_memory compaction summarize_fn: LLM call budget "
-                "exceeded (spec.budget.max_llm_calls)"
-            )
-        prompt = [
-            {"role": "system", "content": SUMMARIZE_INSTRUCTIONS},
-            {"role": "user", "content": json.dumps(messages, default=str)},
-        ]
-        if budget is not None:
-            budget.note_llm()
-        logger.debug("working_memory compaction: summarizing %d message(s) via LLM", len(messages))
-        if getattr(engine, "_uses_model_access", None) and engine._uses_model_access():
-            message = engine._model_access_chat(prompt, tools=None, temperature=0.0)
-        else:
-            api_key = os.environ.get(getattr(engine, "api_key_env", ""), "")
-            message = engine._chat_completion(prompt, api_key=api_key, tools=None, temperature=0.0)
-        content = message.get("content") if isinstance(message, dict) else getattr(message, "content", "")
-        return str(content or "").strip()
-
-    return summarize_fn
+def _wire_summarize_fn(binding: dict[str, Any], engine: Any) -> dict[str, Any]:
+    """Attach ``summarize_fn`` to a ``summarising`` context_manager binding."""
+    if not is_summarising_context_manager(binding):
+        return binding
+    params = dict(binding.get("params") or {})
+    if callable(params.get("summarize_fn")):
+        return {**binding, "params": params}
+    if isinstance(engine, CompactionSummarizeEngine):
+        params["summarize_fn"] = engine.summarize_messages
+        return {**binding, "params": params}
+    logger.warning(
+        "context_manager.type=summarising needs an engine implementing "
+        "CompactionSummarizeEngine; none available — falling back to keep_recent "
+        "(unbounded history, no compaction)."
+    )
+    return {"type": "stack", "params": {}}
 
 
 def apply_working_memory_compaction(spec: dict[str, Any], *, engine: Any = None) -> None:
-    """Mutate ``spec`` in place: synthesize ``spec.context_manager`` from
-    ``spec.working_memory.compaction`` when applicable (see
-    ``resolve_working_memory_context_manager``).
+    """Mutate ``spec`` in place: resolve ``context_manager`` from WM compaction
+    sugar when needed, then wire ``summarize_fn`` for ``SummarizingConversation``.
 
-    When the resolved strategy is ``summarize``, a real ``summarize_fn`` is
-    wired in only if ``engine`` looks like a live LLM engine (has the
-    completion primitives ``build_llm_summarize_fn`` needs) -- a mock/
-    simulated engine has no model to call, so compaction degrades to
-    ``keep_recent`` with a warning rather than crashing at first use.
+    Author-facing config lives under ``spec.working_memory.compaction``. The
+    translated ``context_manager`` binding is the assembly-time plugin hook
+    only; commit-time chunk compaction reads ``working_memory_compaction_runtime``
+    on ``AutoCtxAssembler`` instead.
     """
     binding = resolve_working_memory_context_manager(spec)
-    if binding is None:
+    if binding is not None:
+        spec["context_manager"] = _wire_summarize_fn(binding, engine)
         return
-    if binding["type"] == "summarising":
-        if engine is not None and hasattr(engine, "_chat_completion"):
-            binding["params"]["summarize_fn"] = build_llm_summarize_fn(engine)
-        else:
-            logger.warning(
-                "working_memory.compaction.strategy=summarize needs a live LLM "
-                "engine to build summaries; none available here — falling back "
-                "to keep_recent (unbounded history, no compaction)."
-            )
-            binding = {"type": "stack", "params": {}}
-    spec["context_manager"] = binding
+    cm = spec.get("context_manager")
+    if isinstance(cm, dict):
+        spec["context_manager"] = _wire_summarize_fn(cm, engine)

--- a/runtime/src/mas/runtime/boundary/context/working_memory_registry.py
+++ b/runtime/src/mas/runtime/boundary/context/working_memory_registry.py
@@ -23,13 +23,19 @@ for it).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from mas.runtime.boundary.context.conversation_chunks import ConversationChunkStore
+
+if TYPE_CHECKING:
+    from mas.runtime.driver.mocks import AutoCtxAssembler
 
 
 @dataclass
 class WorkingMemorySnapshot:
     turn_history: list[tuple[str, str]] = field(default_factory=list)
     committed_messages: list[dict[str, Any]] = field(default_factory=list)
+    conversation_chunks: dict[str, Any] | None = None
 
 
 @dataclass
@@ -73,24 +79,33 @@ class WorkingMemoryRegistry:
         self._store.clear()
 
 
-def snapshot_ctx(ctx: Any) -> WorkingMemorySnapshot:
+def snapshot_ctx(ctx: "AutoCtxAssembler") -> WorkingMemorySnapshot:
     """Capture the cross-turn conversation buffer off an ``AutoCtxAssembler``."""
+    chunk_store = ctx.conversation_chunks
+    chunks_dict = (
+        chunk_store.to_dict()
+        if chunk_store.order or chunk_store.summary_chunk_id
+        else None
+    )
     return WorkingMemorySnapshot(
-        turn_history=list(getattr(ctx, "turn_history", ())),
-        committed_messages=list(getattr(ctx, "committed_messages", ())),
+        turn_history=list(ctx.turn_history),
+        committed_messages=list(ctx.committed_messages),
+        conversation_chunks=chunks_dict,
     )
 
 
-def restore_ctx(ctx: Any, snapshot: WorkingMemorySnapshot) -> None:
+def restore_ctx(ctx: "AutoCtxAssembler", snapshot: WorkingMemorySnapshot) -> None:
     """Replace ``ctx``'s cross-turn conversation buffer with a saved snapshot."""
     ctx.turn_history = list(snapshot.turn_history)
     ctx.committed_messages = list(snapshot.committed_messages)
+    ctx.conversation_chunks = ConversationChunkStore.from_dict(snapshot.conversation_chunks)
 
 
-def clear_ctx_working_memory(ctx: Any) -> None:
+def clear_ctx_working_memory(ctx: "AutoCtxAssembler") -> None:
     """Start ``ctx`` fresh for a non-persistent agent (system prompt untouched)."""
     ctx.turn_history = []
     ctx.committed_messages = []
+    ctx.conversation_chunks = ConversationChunkStore()
 
 
 def is_persistent(instance: Any) -> bool:

--- a/runtime/src/mas/runtime/driver/mocks.py
+++ b/runtime/src/mas/runtime/driver/mocks.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from mas.runtime.boundary.context.chunk_compaction import maybe_compact_chunks_after_commit
+from mas.runtime.boundary.context.conversation_chunks import ConversationChunkStore
 from mas.runtime.boundary.context.dp_inject import inject_dp_protocol
 from mas.runtime.boundary.context.plugin_collection import PluginCollection
 from mas.runtime.boundary.context.working_memory import WorkingMemoryStore
+from mas.runtime.boundary.context.working_memory_compaction import WorkingMemoryCompactionRuntime
 from mas.runtime.schema.egress import RequestCtxAssembly
 from mas.runtime.schema.ingress import CtxAssemblyComplete
 
@@ -27,6 +30,10 @@ class AutoCtxAssembler:
     turn_index: int = 0
     turn_history: list[tuple[str, str]] = field(default_factory=list)
     committed_messages: list[dict[str, Any]] = field(default_factory=list)
+    conversation_chunks: ConversationChunkStore = field(default_factory=ConversationChunkStore)
+    # Commit-time WM compaction (chunk graph) — set at bootstrap from
+    # spec.working_memory.compaction; distinct from context_manager assembly plugin.
+    working_memory_compaction: WorkingMemoryCompactionRuntime | None = None
     working_memory: WorkingMemoryStore = field(default_factory=WorkingMemoryStore)
     pattern_plugin_id: str = "react@v1"
     runtime_params: dict[str, Any] = field(default_factory=dict)
@@ -60,6 +67,7 @@ class AutoCtxAssembler:
             self.injected_context = list(baseline)
         self.turn_history.clear()
         self.committed_messages.clear()
+        self.conversation_chunks = ConversationChunkStore()
         self.working_memory.clear()
         self.last_user_text = ""
         self.turn_index = 0
@@ -96,6 +104,7 @@ class AutoCtxAssembler:
     def note_agent_response(self, text: str) -> None:
         from mas.runtime.boundary.context.telemetry import record_context_mutation
 
+        committed_before = len(self.committed_messages)
         if self.last_user_text:
             self.committed_messages.append({"role": "user", "content": self.last_user_text})
             self.turn_history.append((self.last_user_text, text))
@@ -115,6 +124,13 @@ class AutoCtxAssembler:
                 and str(last.get("content") or "").strip() == text.strip()
             ):
                 self.committed_messages.append({"role": "assistant", "content": text})
+        turn_messages = list(self.committed_messages[committed_before:])
+        if turn_messages:
+            self.conversation_chunks.append_turn(turn_messages)
+            maybe_compact_chunks_after_commit(
+                self.conversation_chunks,
+                compaction=self.working_memory_compaction,
+            )
         record_context_mutation(
             self.observability,
             action="turn_commit",

--- a/runtime/src/mas/runtime/engine/infra_pipeline.py
+++ b/runtime/src/mas/runtime/engine/infra_pipeline.py
@@ -190,3 +190,11 @@ class BidirectionalPipelineEngine:
         reset_fn = getattr(self.inner, "reset_turn_state", None)
         if callable(reset_fn):
             reset_fn()
+
+    def summarize_messages(self, messages: list[dict[str, Any]]) -> str:
+        from mas.runtime.engine.protocol import CompactionSummarizeEngine
+
+        inner = self.inner
+        if not isinstance(inner, CompactionSummarizeEngine):
+            raise TypeError(f"{type(inner).__name__} does not implement CompactionSummarizeEngine")
+        return inner.summarize_messages(messages)

--- a/runtime/src/mas/runtime/engine/llm_live.py
+++ b/runtime/src/mas/runtime/engine/llm_live.py
@@ -103,6 +103,29 @@ class LiveLlmEngine:
         self._pending_tool_args = {}
         self._pending_tools_by_cid.clear()
 
+    def summarize_messages(self, messages: list[dict[str, Any]]) -> str:
+        """CompactionSummarizeEngine — one-off summary via this engine's model."""
+        from mas.runtime.boundary.context.working_memory_compaction import SUMMARIZE_INSTRUCTIONS
+
+        if not self._budget.allow_llm():
+            raise RuntimeError(
+                "working_memory compaction summarize_fn: LLM call budget "
+                "exceeded (spec.budget.max_llm_calls)"
+            )
+        prompt = [
+            {"role": "system", "content": SUMMARIZE_INSTRUCTIONS},
+            {"role": "user", "content": json.dumps(messages, default=str)},
+        ]
+        self._budget.note_llm()
+        logger.debug("working_memory compaction: summarizing %d message(s) via LLM", len(messages))
+        if self._uses_model_access():
+            message = self._model_access_chat(prompt, tools=None, temperature=0.0)
+        else:
+            api_key = os.environ.get(self.api_key_env, "")
+            message = self._chat_completion(prompt, api_key=api_key, tools=None, temperature=0.0)
+        content = message.get("content") if isinstance(message, dict) else getattr(message, "content", "")
+        return str(content or "").strip()
+
     def exchange_preview(self, op: str) -> str:
         """Ctl --trace: describe outbound LLM payload or pending tool call."""
         if op == "LLM_CALL":

--- a/runtime/src/mas/runtime/engine/protocol.py
+++ b/runtime/src/mas/runtime/engine/protocol.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from mas.runtime.schema.egress import InvokeEngineIo
 from mas.runtime.schema.ingress import EngineIoReturn
@@ -15,3 +15,10 @@ class EngineContract(Protocol):
     """Invoke engine I/O requested by kernel egress (M_model / M_tool)."""
 
     def invoke(self, io: InvokeEngineIo) -> EngineIoReturn: ...
+
+
+@runtime_checkable
+class CompactionSummarizeEngine(Protocol):
+    """Out-of-band summarization for commit-time / view-time context compaction."""
+
+    def summarize_messages(self, messages: list[dict[str, Any]]) -> str: ...

--- a/runtime/tests/integration/test_working_memory_compaction.py
+++ b/runtime/tests/integration/test_working_memory_compaction.py
@@ -2,6 +2,8 @@
 #  SPDX-License-Identifier: Apache-2.0
 """spec.working_memory.compaction facade over context_manager/CMFactory."""
 
+import json
+
 import pytest
 from mas.library.standard.plugins.context.conversation import (
     SlidingWindowConversation,
@@ -9,10 +11,12 @@ from mas.library.standard.plugins.context.conversation import (
     SummarizingConversation,
 )
 from mas.runtime.boundary.context.working_memory_compaction import (
+    SUMMARIZE_INSTRUCTIONS,
     apply_working_memory_compaction,
     build_llm_summarize_fn,
     context_manager_binding_from_compaction,
     resolve_working_memory_context_manager,
+    working_memory_compaction_runtime,
 )
 from mas.runtime.contracts.cm_factory import CMFactory
 
@@ -80,6 +84,14 @@ class _FakeEngineNoModelAccess:
         assert temperature == 0.0
         return {"role": "assistant", "content": f"summary of {len(messages)} prompt messages"}
 
+    def summarize_messages(self, messages):
+        prompt = [
+            {"role": "system", "content": SUMMARIZE_INSTRUCTIONS},
+            {"role": "user", "content": json.dumps(messages, default=str)},
+        ]
+        message = self._chat_completion(prompt, api_key="", tools=None, temperature=0.0)
+        return str(message.get("content") or "").strip()
+
 
 class _FakeEngineModelAccess:
     def _uses_model_access(self):
@@ -88,6 +100,14 @@ class _FakeEngineModelAccess:
     def _model_access_chat(self, messages, *, tools, temperature):
         assert tools is None
         return {"role": "assistant", "content": "summary via model access"}
+
+    def summarize_messages(self, messages):
+        prompt = [
+            {"role": "system", "content": SUMMARIZE_INSTRUCTIONS},
+            {"role": "user", "content": json.dumps(messages, default=str)},
+        ]
+        message = self._model_access_chat(prompt, tools=None, temperature=0.0)
+        return str(message.get("content") or "").strip()
 
 
 def test_build_llm_summarize_fn_uses_chat_completion_path():
@@ -127,6 +147,27 @@ def test_apply_working_memory_compaction_summarize_with_live_engine():
     assert isinstance(cm, SummarizingConversation)
 
 
+def test_working_memory_compaction_runtime_from_spec():
+    spec = {"working_memory": {"compaction": {"strategy": "summarize", "keep_turns": 3}}}
+    apply_working_memory_compaction(spec, engine=_FakeEngineNoModelAccess())
+    runtime = working_memory_compaction_runtime(spec)
+    assert runtime is not None
+    assert runtime.keep_turns == 3
+    assert runtime.summarize_fn([{"role": "user", "content": "hi"}]) == "summary of 2 prompt messages"
+
+
+def test_apply_working_memory_compaction_wires_explicit_summarising_context_manager():
+    spec = {
+        "context_manager": {
+            "type": "summarising",
+            "params": {"summary_threshold": 1000, "keep_turns": 2},
+        }
+    }
+    apply_working_memory_compaction(spec, engine=_FakeEngineNoModelAccess())
+    assert spec["context_manager"]["type"] == "summarising"
+    assert callable(spec["context_manager"]["params"]["summarize_fn"])
+
+
 def test_apply_working_memory_compaction_summarize_without_engine_degrades_to_keep_recent():
     """No live LLM engine available -- must not crash; falls back safely."""
     spec = {"working_memory": {"compaction": {"strategy": "summarize"}}}
@@ -153,6 +194,15 @@ class _FakeEngineWithBudget(_FakeEngineNoModelAccess):
         from mas.runtime.boundary.gov.budget import BudgetTracker
 
         self._budget = BudgetTracker(max_llm_calls=max_llm_calls)
+
+    def summarize_messages(self, messages):
+        if not self._budget.allow_llm():
+            raise RuntimeError(
+                "working_memory compaction summarize_fn: LLM call budget "
+                "exceeded (spec.budget.max_llm_calls)"
+            )
+        self._budget.note_llm()
+        return super().summarize_messages(messages)
 
 
 def test_build_llm_summarize_fn_counts_against_engine_budget():

--- a/runtime/tests/integration/test_working_memory_registry.py
+++ b/runtime/tests/integration/test_working_memory_registry.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 
+from mas.runtime.boundary.context.conversation_chunks import ConversationChunkStore
 from mas.runtime.boundary.context.working_memory_registry import (
     WorkingMemoryConfig,
     WorkingMemoryRegistry,
@@ -17,12 +18,14 @@ from mas.runtime.boundary.context.working_memory_registry import (
     sync_working_memory_in,
     sync_working_memory_out,
 )
+from mas.runtime.driver.mocks import AutoCtxAssembler
 
 
 class _FakeCtx:
     def __init__(self, turn_history=None, committed_messages=None):
         self.turn_history = list(turn_history or [])
         self.committed_messages = list(committed_messages or [])
+        self.conversation_chunks = ConversationChunkStore()
 
 
 def _fake_instance(*, persistent: bool = True, ctx: "_FakeCtx | None" = None) -> SimpleNamespace:
@@ -184,3 +187,20 @@ def test_sync_working_memory_out_does_not_save_when_not_persistent():
     instance = _fake_instance(persistent=False, ctx=ctx)
     sync_working_memory_out(instance, memory_key="s", agent_id="a")
     assert get_working_memory_registry().get("s", "a") is None
+
+
+def test_sync_working_memory_round_trips_conversation_chunks():
+    reset_working_memory_registry()
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("hello")
+    ctx.note_agent_response("world")
+    instance = _fake_instance(ctx=ctx)
+    sync_working_memory_out(instance, memory_key="sess-1", agent_id="agent-a")
+
+    fresh = AutoCtxAssembler()
+    fresh.conversation_chunks = ConversationChunkStore()
+    instance.driver.ctx = fresh
+    sync_working_memory_in(instance, memory_key="sess-1", agent_id="agent-a")
+
+    assert fresh.conversation_chunks.project_messages()
+    assert any(m.get("content") == "hello" for m in fresh.conversation_chunks.project_messages())

--- a/runtime/tests/test_conversation_chunks.py
+++ b/runtime/tests/test_conversation_chunks.py
@@ -1,0 +1,285 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""Commit-time conversation chunk graph."""
+
+from __future__ import annotations
+
+from mas.library.standard.plugins.context.provider_payload import assert_provider_payload
+from mas.runtime.boundary.context.assemble import assemble_llm_messages
+from mas.runtime.boundary.context.chunk_compaction import maybe_compact_chunks_after_commit
+from mas.runtime.boundary.context.conversation_chunks import (
+    ConversationChunkStore,
+    MessageChunk,
+    SummaryChunk,
+)
+from mas.runtime.boundary.context.working_memory_compaction import WorkingMemoryCompactionRuntime
+from mas.runtime.boundary.context.working_memory_registry import (
+    WorkingMemorySnapshot,
+    restore_ctx,
+    snapshot_ctx,
+)
+from mas.runtime.driver.mocks import AutoCtxAssembler
+
+
+def _turn(user: str, assistant: str) -> list[dict]:
+    return [
+        {"role": "user", "content": user},
+        {"role": "assistant", "content": assistant},
+    ]
+
+
+def _tool_turn(call_id: str = "call_1") -> list[dict]:
+    return [
+        {"role": "user", "content": "ask"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": call_id, "function": {"name": "search", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": "result"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def test_append_and_project_message_chunks() -> None:
+    store = ConversationChunkStore()
+    store.append_turn(_turn("q1", "a1"))
+    store.append_turn(_turn("q2", "a2"))
+    projected = store.project_messages()
+    assert len(projected) == 4
+    assert projected[0]["content"] == "q1"
+    assert projected[-1]["content"] == "a2"
+
+
+def test_empty_append_returns_empty_id() -> None:
+    store = ConversationChunkStore()
+    assert store.append_turn([]) == ""
+    assert store.project_messages() == []
+
+
+def test_project_summary_before_recent_chunks() -> None:
+    store = ConversationChunkStore()
+    store.append_turn(_turn("old", "a"))
+    store.summary_chunk_id = "sum_1"
+    store.chunks["sum_1"] = SummaryChunk(
+        chunk_id="sum_1",
+        text="rolled",
+        child_chunk_ids=[],
+    )
+    store.append_turn(_turn("new", "b"))
+    projected = store.project_messages()
+    assert projected[0]["role"] == "system"
+    assert projected[-1]["content"] == "b"
+
+
+def test_compact_retains_child_chunks_for_audit() -> None:
+    store = ConversationChunkStore()
+    for i in range(6):
+        store.append_turn(_turn(f"q{i}", "x" * 500))
+
+    def summarize(msgs: list) -> str:
+        return "summary-text"
+
+    assert store.maybe_compact(
+        summary_threshold=100,
+        keep_message_chunks=2,
+        summarize_fn=summarize,
+    )
+    assert store.summary_chunk_id
+    summary = store.chunks[store.summary_chunk_id]
+    assert isinstance(summary, SummaryChunk)
+    assert summary.text == "summary-text"
+    assert len(summary.child_chunk_ids) == 4
+    assert len(store.order) == 2
+    for child_id in summary.child_chunk_ids:
+        assert child_id in store.chunks
+        assert isinstance(store.chunks[child_id], MessageChunk)
+
+
+def test_second_compact_is_incremental_not_full_rescan() -> None:
+    store = ConversationChunkStore()
+    calls = 0
+
+    def summarize(msgs: list) -> str:
+        nonlocal calls
+        calls += 1
+        if any("[Prior summary]" in str(m.get("content", "")) for m in msgs):
+            return "summary-v2"
+        return "summary-v1"
+
+    for i in range(4):
+        store.append_turn(_turn(f"q{i}", "y" * 400))
+    store.maybe_compact(summary_threshold=50, keep_message_chunks=1, summarize_fn=summarize)
+    store.append_turn(_turn("q4", "y" * 400))
+    store.append_turn(_turn("q5", "y" * 400))
+    store.maybe_compact(summary_threshold=50, keep_message_chunks=1, summarize_fn=summarize)
+    assert calls == 2
+    assert store.chunks[store.summary_chunk_id].text == "summary-v2"
+
+
+def test_maybe_compact_noop_under_threshold() -> None:
+    store = ConversationChunkStore()
+    store.append_turn(_turn("a", "short"))
+    assert not store.maybe_compact(
+        summary_threshold=10_000,
+        keep_message_chunks=1,
+        summarize_fn=lambda m: "nope",
+    )
+
+
+def test_maybe_compact_noop_when_keep_covers_all_chunks() -> None:
+    store = ConversationChunkStore()
+    store.append_turn(_turn("a", "x" * 500))
+    store.append_turn(_turn("b", "x" * 500))
+    assert not store.maybe_compact(
+        summary_threshold=10,
+        keep_message_chunks=5,
+        summarize_fn=lambda m: "nope",
+    )
+
+
+def test_serialization_round_trip() -> None:
+    store = ConversationChunkStore()
+    cid = store.append_turn(_turn("u", "x" * 500))
+    assert store.maybe_compact(
+        summary_threshold=50,
+        keep_message_chunks=0,
+        summarize_fn=lambda m: "sum",
+    )
+    restored = ConversationChunkStore.from_dict(store.to_dict())
+    assert restored.summary_chunk_id == store.summary_chunk_id
+    assert restored.order == store.order
+    assert set(restored.chunks) == set(store.chunks)
+    assert restored.project_messages() == store.project_messages()
+    summary = restored.chunks[restored.summary_chunk_id]
+    assert isinstance(summary, SummaryChunk)
+    assert cid in summary.child_chunk_ids
+
+
+def test_from_dict_none_returns_empty_store() -> None:
+    store = ConversationChunkStore.from_dict(None)
+    assert store.order == []
+    assert store.chunks == {}
+
+
+def test_assembly_uses_chunk_projection_over_flat_committed() -> None:
+    ctx = AutoCtxAssembler(last_user_text="follow-up")
+    ctx.committed_messages = [{"role": "user", "content": "stale"}]
+    ctx.conversation_chunks.append_turn(_turn("from-chunk", "answer"))
+    messages = assemble_llm_messages(ctx)
+    assert any(m.get("content") == "from-chunk" for m in messages)
+    assert not any(m.get("content") == "stale" for m in messages)
+    assert messages[-1]["content"] == "follow-up"
+
+
+def test_assembly_chunk_projection_is_provider_safe() -> None:
+    ctx = AutoCtxAssembler(last_user_text="next")
+    ctx.conversation_chunks.append_turn(_tool_turn("call_a"))
+    ctx.conversation_chunks.append_turn(_tool_turn("call_b"))
+    messages = assemble_llm_messages(ctx)
+    assert_provider_payload(messages)
+
+
+def test_assembly_does_not_invoke_summarize_fn() -> None:
+    ctx = AutoCtxAssembler(last_user_text="q")
+    ctx.working_memory_compaction = WorkingMemoryCompactionRuntime(
+        summary_threshold=10,
+        keep_turns=0,
+        summarize_fn=lambda m: (_ for _ in ()).throw(AssertionError("no assembly summarize")),
+    )
+    ctx.conversation_chunks.append_turn(_turn("a", "b" * 500))
+    # working_memory_compaction is commit-time only; assembly uses manifest/CMFactory.
+    assemble_llm_messages(ctx)
+    assemble_llm_messages(ctx)
+
+
+def test_turn_commit_appends_chunk_and_compacts_at_commit_only() -> None:
+    ctx = AutoCtxAssembler()
+    calls = 0
+
+    def summarize(msgs: list) -> str:
+        nonlocal calls
+        calls += 1
+        return "rolled-up"
+
+    ctx.working_memory_compaction = WorkingMemoryCompactionRuntime(
+        summary_threshold=80,
+        keep_turns=1,
+        summarize_fn=summarize,
+    )
+    for i in range(4):
+        ctx.note_user_input(f"q{i}")
+        ctx.note_agent_response("x" * 200)
+    assert calls >= 1
+    assert ctx.conversation_chunks.summary_chunk_id
+    projected = ctx.conversation_chunks.project_messages()
+    assert projected[0]["role"] == "system"
+    assert "rolled-up" in projected[0]["content"]
+
+
+def test_maybe_compact_chunks_after_commit_respects_manifest() -> None:
+    store = ConversationChunkStore()
+    store.append_turn(_turn("a", "x" * 800))
+    assert not maybe_compact_chunks_after_commit(store, compaction=None)
+    assert maybe_compact_chunks_after_commit(
+        store,
+        compaction=WorkingMemoryCompactionRuntime(
+            summary_threshold=50,
+            keep_turns=0,
+            summarize_fn=lambda m: "ok",
+        ),
+    )
+
+
+def test_tool_trajectory_preserved_in_message_chunk() -> None:
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("Who is POTUS?")
+    ctx.record_assistant_tool_call(call_id="call_1", tool_name="search", arguments={})
+    ctx.record_tool_result(call_id="call_1", content="Donald Trump")
+    ctx.note_agent_response("Donald Trump is POTUS.")
+    chunk_ids = [cid for cid in ctx.conversation_chunks.order]
+    assert len(chunk_ids) == 1
+    chunk = ctx.conversation_chunks.chunks[chunk_ids[0]]
+    assert any(m.get("role") == "tool" for m in chunk.messages)
+    assert_provider_payload(chunk.messages)
+
+
+def test_snapshot_round_trips_chunk_store() -> None:
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("hello")
+    ctx.note_agent_response("world")
+    snap = snapshot_ctx(ctx)
+    other = AutoCtxAssembler()
+    restore_ctx(other, snap)
+    assert other.conversation_chunks.project_messages() == ctx.conversation_chunks.project_messages()
+
+
+def test_working_memory_snapshot_carries_chunks_dict() -> None:
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("a")
+    ctx.note_agent_response("b")
+    snap = snapshot_ctx(ctx)
+    assert snap.conversation_chunks is not None
+    assert snap.conversation_chunks["order"]
+
+
+def test_restore_empty_snapshot_clears_chunks() -> None:
+    ctx = AutoCtxAssembler()
+    ctx.note_user_input("a")
+    ctx.note_agent_response("b")
+    restore_ctx(ctx, WorkingMemorySnapshot())
+    assert ctx.conversation_chunks.order == []
+
+
+def test_multi_session_chunk_stores_are_independent() -> None:
+    ctx_a = AutoCtxAssembler(session_id="a")
+    ctx_b = AutoCtxAssembler(session_id="b")
+    ctx_a.note_user_input("A")
+    ctx_a.note_agent_response("a")
+    ctx_b.note_user_input("B")
+    ctx_b.note_agent_response("b")
+    assert ctx_a.conversation_chunks.order != ctx_b.conversation_chunks.order
+    msgs_a = assemble_llm_messages(ctx_a, manifest={"spec": {}})
+    msgs_b = assemble_llm_messages(ctx_b, manifest={"spec": {}})
+    assert any("A" in str(m.get("content")) for m in msgs_a)
+    assert any("B" in str(m.get("content")) for m in msgs_b)

--- a/runtime/tests/test_outbound_wait_assembly.py
+++ b/runtime/tests/test_outbound_wait_assembly.py
@@ -41,7 +41,6 @@ def test_working_memory_pinned_whole_in_turn() -> None:
     q = QProduct()
     register_inflight(q, 7, kind="TOOL", op="TOOL_CALL")
     ctx = AutoCtxAssembler(last_user_text="continue")
-    ctx.q_product = q
     ctx.record_assistant_tool_call(call_id="call_7", tool_name="search", arguments={})
     ctx.record_tool_result(call_id="call_7", content="partial")
     ctx.record_assistant_tool_call(call_id="call_8", tool_name="search", arguments={})
@@ -51,10 +50,7 @@ def test_working_memory_pinned_whole_in_turn() -> None:
 
 
 def test_assemble_pins_wm_under_budget() -> None:
-    q = QProduct()
-    register_inflight(q, 1, kind="TOOL", op="TOOL_CALL")
     ctx = AutoCtxAssembler(last_user_text="Who is POTUS?")
-    ctx.q_product = q
     ctx.record_assistant_tool_call(call_id="call_1", tool_name="web-search", arguments={"q": "POTUS"})
     ctx.record_tool_result(call_id="call_1", content="Donald Trump is president.")
     manifest = {
@@ -86,11 +82,7 @@ def test_assemble_committed_history_provider_safe_after_stack_trim() -> None:
 
 
 def test_inflight_partial_parallel_tools_preserved_in_payload() -> None:
-    q = QProduct()
-    register_inflight(q, 10, kind="TOOL", op="TOOL_CALL")
-    register_inflight(q, 11, kind="TOOL", op="TOOL_CALL")
     ctx = AutoCtxAssembler(last_user_text="continue")
-    ctx.q_product = q
     ctx.working_memory.record_assistant_tool_calls(
         [
             ("call_a", "search", {"q": "a"}),
@@ -160,9 +152,6 @@ def test_assembler_preserves_live_turn_inflight_tool_calls() -> None:
 
 def test_high_level_react_path_still_sees_tool_result() -> None:
     ctx = AutoCtxAssembler(last_user_text="Who is POTUS?")
-    q = QProduct()
-    register_inflight(q, 1, kind="TOOL", op="TOOL_CALL")
-    ctx.q_product = q
     ctx.record_assistant_tool_call(call_id="call_1", tool_name="web-search", arguments={"q": "POTUS"})
     ctx.record_tool_result(call_id="call_1", content="Donald Trump is president.")
     messages = assemble_llm_messages(ctx)
@@ -177,12 +166,10 @@ def test_concurrent_sessions_have_isolated_kernel_and_assembly() -> None:
     register_inflight(q_a, 1, kind="TOOL", op="TOOL_CALL")
 
     ctx_a = AutoCtxAssembler(session_id="sess-a", last_user_text="A")
-    ctx_a.q_product = q_a
     ctx_a.record_assistant_tool_call(call_id="call_a", tool_name="search", arguments={})
     ctx_a.record_tool_result(call_id="call_a", content="result-a")
 
     ctx_b = AutoCtxAssembler(session_id="sess-b", last_user_text="B")
-    ctx_b.q_product = q_b
 
     msgs_a = assemble_llm_messages(ctx_a)
     msgs_b = assemble_llm_messages(ctx_b)


### PR DESCRIPTION
- Incremental summarization at turn commit (chunk store retains children for audit)
- Assembly projects chunk graph; WM compaction runtime holds summarize_fn (not CM ctx state)
- CompactionSummarizeEngine protocol; strict summarising schema; wire via working_memory.compaction

Signed-off-by: Jordan Augé <augjorda@cisco.com>
