### PR TITLE
fix(runtime): configure engine queue depth via spec.execution

### DIFF
--- a/ctl/src/mas/ctl/manifest/spec_bindings.py
+++ b/ctl/src/mas/ctl/manifest/spec_bindings.py
@@ -186,7 +186,9 @@ def parse_governance(raw: Any) -> GovernanceBinding:
 
 
 _LLM_KEYS = frozenset({"model", "provider", "temperature", "max_tokens"})
-_EXECUTION_KEYS = frozenset({"mocking", "cache", "parallel", "live", "timeout"})
+_EXECUTION_KEYS = frozenset(
+    {"mocking", "cache", "parallel", "engine_queue_depth", "live", "stream", "timeout"}
+)
 _CONTROL_KEYS = frozenset({"budget", "circuit_breaker", "rate_limiter"})
 
 
@@ -238,6 +240,9 @@ def parse_execution(raw: Any) -> None:
         _reject_unknown_keys(
             cache, allowed=frozenset({"enabled", "read", "write"}), field="spec.execution.cache"
         )
+    depth = raw.get("engine_queue_depth")
+    if depth is not None and (not isinstance(depth, int) or isinstance(depth, bool) or depth < 1):
+        raise SpecBindingError("spec.execution.engine_queue_depth must be an integer >= 1")
 
 
 def parse_control(raw: Any) -> None:

--- a/docs/manifests/agent.md
+++ b/docs/manifests/agent.md
@@ -31,7 +31,7 @@ sees, and which plugins hook its execution.
 | Memory | `memory`, `memory_seed` | Stores + startup seeds |
 | Working memory | `working_memory.persistent` | Cross-turn buffer survives repeat delegate calls within one session (default `true`) — see below |
 | Kernel plugins | `plugins[]`, `governance[]`, `observability[]` | Governance and observability on Mealy envelope chokepoints (not a hook plane) |
-| Execution mode | `execution` | Mocking, LLM response cache read/write, parallel tool calls — see [execution.md](execution.md) |
+| Execution mode | `execution` | Mocking, LLM cache, parallel tools, engine queue depth — see [execution.md](execution.md) |
 
 ---
 

--- a/docs/manifests/execution.md
+++ b/docs/manifests/execution.md
@@ -6,11 +6,15 @@
 
 **Package:** `mas-runtime`, `mas-ctl` · **Schema:** `execution-binding.schema.yaml`
 
-`spec.execution` is an **Agent** manifest block that controls how a turn actually
-runs: whether it hits a real model or a mock one, whether the LLM response
-cache is consulted, and whether tool calls can run in parallel. It does not
-describe *what* the agent does (that's `spec.context`, `spec.tools`,
-`spec.skills`) — only how the engine executes it.
+`spec.execution` lives on **`kind: Agent`** manifests (`agent.yaml`) and on
+**overlays** that patch an agent (`spec.patch.execution`). It is execution
+configuration — how the runtime engine runs a turn — not agent logic
+(`spec.context`, `spec.tools`, `spec.design_pattern`, `spec.skills`).
+
+It controls whether a turn hits a real model or a mock one, whether the LLM
+response cache is consulted, whether tool calls may run in parallel, and how
+large a single parallel tool batch may be before the engine queue rejects
+overflow.
 
 **Terms:** [glossary.md](../glossary.md) · Hub: [README.md](README.md).
 
@@ -24,6 +28,7 @@ spec:
       read: true
       write: true
     parallel: true
+    engine_queue_depth: 32
 ```
 
 All fields are optional; every default below is what you get by omitting the
@@ -125,6 +130,32 @@ the model may request more than one tool call in a single turn, executed
 concurrently. Set `false` to force strictly sequential tool calls regardless
 of what the design pattern would otherwise allow.
 
+## `engine_queue_depth`
+
+```yaml
+execution:
+  engine_queue_depth: 32   # default: 32
+```
+
+Caps how many engine egress intents (`LLM_CALL` / `TOOL_CALL`) the kernel may
+queue for **one dispatch batch** before draining them. When the model returns
+more parallel tool calls than this limit, the runtime raises
+`engine outbound queue full` on the overflow.
+
+This is **not** thread-pool concurrency: `EngineWorkerPool` drains the queue
+sequentially via `engine.invoke()`. The limit bounds batch size and memory for
+a single model turn that schedules many tools at once (for example one script
+invocation per candidate in a multi-tool reply).
+
+| | |
+|---|---|
+| Manifest | `spec.execution.engine_queue_depth` (integer ≥ 1, default **32**) |
+| Runtime | `KernelConfig.engine_queue_depth` → `EngineWorkerPool.max_depth` |
+| Source | `runtime/src/mas/runtime/engine/worker_pool.py`, `runtime/src/mas/runtime/driver/driver.py` |
+
+Raise the value when a legitimate workload schedules more than 32 parallel tool
+calls in one turn. Lower it to fail fast on runaway tool batches.
+
 ## `live` and `timeout`
 
 Both are accepted by the schema (`live: boolean`, `timeout: number`) but are
@@ -138,4 +169,4 @@ explicit live-mode override. Setting them today has no effect.
 - [user-config.md](../user-config.md) — XDG path reference for all MAS caches (trace, artifacts, LLM response)
 - [Tutorial 3 — Experiments, Analysis & Evaluation](../tutorials/03-experiments-and-analysis/README.md) — running experiments, the trace cache
 - [agent.md](agent.md) — the manifest `spec.execution` lives in
-- Source: `runtime/src/mas/runtime/engine/llm_cache.py`, `runtime/src/mas/runtime/xdg.py`, `ctl/src/mas/ctl/session/engine_factory.py`
+- Source: `runtime/src/mas/runtime/engine/llm_cache.py`, `runtime/src/mas/runtime/engine/worker_pool.py`, `runtime/src/mas/runtime/xdg.py`, `ctl/src/mas/ctl/session/engine_factory.py`

--- a/docs/schemas/runtime/fragments/execution-binding.schema.yaml
+++ b/docs/schemas/runtime/fragments/execution-binding.schema.yaml
@@ -31,6 +31,14 @@ properties:
         description: "Persist a response to the cache after calling the LLM. Default: true."
   parallel:
     type: boolean
+  engine_queue_depth:
+    type: integer
+    minimum: 1
+    default: 32
+    description: >
+      Maximum engine egress intents (LLM/tool calls) queued for one kernel
+      dispatch batch before drain. Raise when a single model turn schedules
+      many parallel tool calls. See docs/manifests/execution.md.
   live:
     type: boolean
   stream:

--- a/runtime/src/mas/runtime/driver/driver.py
+++ b/runtime/src/mas/runtime/driver/driver.py
@@ -20,7 +20,7 @@ from mas.runtime.boundary.obs.exchange_plugin import ExchangePlugin
 from mas.runtime.boundary.obs.operator import ObservabilityOperator
 from mas.runtime.driver.mocks import AutoCtxAssembler
 from mas.runtime.engine.simulated import SimulatedEngine
-from mas.runtime.engine.worker_pool import EngineWorkerPool
+from mas.runtime.engine.worker_pool import DEFAULT_ENGINE_QUEUE_DEPTH, EngineWorkerPool
 from mas.runtime.kernel.inflight import pending_for_validate, register_inflight
 from mas.runtime.kernel.orchestrator import RuntimeKernel
 from mas.runtime.kernel.runtime_context import runtime_binding
@@ -139,7 +139,12 @@ class KernelDriver:
 
     def __post_init__(self) -> None:
         if self.engine_pool is None and self.engine is not None:
-            self.engine_pool = EngineWorkerPool(worker=self.engine.invoke)
+            depth = (
+                self.kernel.config.engine_queue_depth
+                if self.kernel is not None
+                else DEFAULT_ENGINE_QUEUE_DEPTH
+            )
+            self.engine_pool = EngineWorkerPool(worker=self.engine.invoke, max_depth=depth)
         if self.ctx is not None and self.observability is not None:
             self.ctx.observability = self.observability
 

--- a/runtime/src/mas/runtime/engine/__init__.py
+++ b/runtime/src/mas/runtime/engine/__init__.py
@@ -3,6 +3,12 @@
 """Engine package — worker pool and simulated adapter."""
 
 from mas.runtime.engine.simulated import SimMode, SimulatedEngine, simulated_next_step
-from mas.runtime.engine.worker_pool import EngineWorkerPool
+from mas.runtime.engine.worker_pool import DEFAULT_ENGINE_QUEUE_DEPTH, EngineWorkerPool
 
-__all__ = ["EngineWorkerPool", "SimMode", "SimulatedEngine", "simulated_next_step"]
+__all__ = [
+    "DEFAULT_ENGINE_QUEUE_DEPTH",
+    "EngineWorkerPool",
+    "SimMode",
+    "SimulatedEngine",
+    "simulated_next_step",
+]

--- a/runtime/src/mas/runtime/engine/worker_pool.py
+++ b/runtime/src/mas/runtime/engine/worker_pool.py
@@ -1,6 +1,6 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-"""Execution engine worker pool — mirrors TLA outbound_queue / inbound_queue."""
+"""In-process engine I/O queue for one kernel dispatch batch."""
 
 from __future__ import annotations
 
@@ -11,18 +11,19 @@ from dataclasses import dataclass, field
 from mas.runtime.schema.egress import InvokeEngineIo
 from mas.runtime.schema.ingress import EngineIoReturn
 
+DEFAULT_ENGINE_QUEUE_DEPTH = 32
 
 WorkerFn = Callable[[InvokeEngineIo], EngineIoReturn]
 
 
 @dataclass
 class EngineWorkerPool:
-    """In-process engine queue: kernel submits InvokeEngineIo, workers produce EngineIoReturn."""
+    """Queue engine egress intents from one batch; drain runs invoke sequentially."""
 
     worker: WorkerFn
     outbound_queue: deque[InvokeEngineIo] = field(default_factory=deque)
     inbound_queue: deque[EngineIoReturn] = field(default_factory=deque)
-    max_depth: int = 8
+    max_depth: int = DEFAULT_ENGINE_QUEUE_DEPTH
 
     def submit(self, intent: InvokeEngineIo) -> None:
         if len(self.outbound_queue) >= self.max_depth:

--- a/runtime/src/mas/runtime/kernel/config.py
+++ b/runtime/src/mas/runtime/kernel/config.py
@@ -1,6 +1,6 @@
 #  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
 #  SPDX-License-Identifier: Apache-2.0
-"""Kernel configuration — mirrors TLA CONSTANT profile flags."""
+"""Kernel configuration — profile flags and per-run execution limits."""
 
 from __future__ import annotations
 
@@ -8,11 +8,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from mas.runtime.agent_defaults import default_pattern_plugin_id
+from mas.runtime.engine.worker_pool import DEFAULT_ENGINE_QUEUE_DEPTH
 from mas.runtime.schema.governance import GovIngressProfile, GovPolicyProfile
 
 if TYPE_CHECKING:
-    from mas.runtime.boundary.gov.policy_engine import GovernancePolicyEngine
     from mas.runtime.boundary.gov.error_recovery import ErrorRecoveryPlugin
+    from mas.runtime.boundary.gov.policy_engine import GovernancePolicyEngine
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,7 @@ class KernelConfig:
     enable_transport_egress: bool = False
     max_cot_pass: int = 1
     parallel_tool_calls: bool = True
+    engine_queue_depth: int = DEFAULT_ENGINE_QUEUE_DEPTH
     policy_engine: GovernancePolicyEngine | None = field(default=None, compare=False)
     error_recovery_plugin: ErrorRecoveryPlugin | None = field(default=None, compare=False)
     ingress_governance_plugins: tuple = field(default=(), compare=False)

--- a/runtime/src/mas/runtime/spec/parser.py
+++ b/runtime/src/mas/runtime/spec/parser.py
@@ -62,13 +62,18 @@ def parse_agent_spec(
         gov_binding, pattern_plugin_id=pattern_plugin_id, agent_spec=spec
     )
 
-    # Apply spec.execution.parallel override
-    if "parallel" in execution:
-        from dataclasses import replace
+    from dataclasses import replace
 
+    # Apply spec.execution overrides (see docs/manifests/execution.md).
+    if "parallel" in execution:
         kernel_config = replace(
             kernel_config,
             parallel_tool_calls=bool(execution["parallel"]),
+        )
+    if "engine_queue_depth" in execution:
+        kernel_config = replace(
+            kernel_config,
+            engine_queue_depth=int(execution["engine_queue_depth"]),
         )
 
     obs_binding = parse_obs_spec(obs_raw)

--- a/runtime/tests/test_engine_worker_pool.py
+++ b/runtime/tests/test_engine_worker_pool.py
@@ -1,0 +1,51 @@
+#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#  SPDX-License-Identifier: Apache-2.0
+"""EngineWorkerPool — batch queue depth and manifest wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from mas.ctl.manifest.spec_bindings import SpecBindingError, parse_execution
+from mas.runtime.driver.driver import KernelDriver
+from mas.runtime.engine.worker_pool import DEFAULT_ENGINE_QUEUE_DEPTH, EngineWorkerPool
+from mas.runtime.kernel.config import KernelConfig
+from mas.runtime.kernel.orchestrator import RuntimeKernel
+from mas.runtime.schema.egress import InvokeEngineIo
+from mas.runtime.spec.parser import parse_agent_spec
+
+
+def test_default_queue_depth_constant():
+    assert DEFAULT_ENGINE_QUEUE_DEPTH == 32
+
+
+def test_submit_rejects_when_queue_full():
+    pool = EngineWorkerPool(worker=MagicMock(), max_depth=2)
+    pool.submit(InvokeEngineIo(correlation_id=1, op="TOOL_CALL"))
+    pool.submit(InvokeEngineIo(correlation_id=2, op="TOOL_CALL"))
+    with pytest.raises(RuntimeError, match="engine outbound queue full"):
+        pool.submit(InvokeEngineIo(correlation_id=3, op="TOOL_CALL"))
+
+
+def test_parse_agent_spec_reads_engine_queue_depth():
+    config, _ = parse_agent_spec({"execution": {"engine_queue_depth": 64}})
+    assert config.engine_queue_depth == 64
+
+
+def test_parse_agent_spec_default_engine_queue_depth():
+    config, _ = parse_agent_spec({})
+    assert config.engine_queue_depth == DEFAULT_ENGINE_QUEUE_DEPTH
+
+
+def test_parse_execution_validates_engine_queue_depth():
+    parse_execution({"engine_queue_depth": 16})
+    with pytest.raises(SpecBindingError, match="engine_queue_depth"):
+        parse_execution({"engine_queue_depth": 0})
+
+
+def test_driver_engine_pool_uses_kernel_config_depth():
+    kernel = RuntimeKernel(config=KernelConfig(engine_queue_depth=12))
+    driver = KernelDriver(kernel=kernel, engine=MagicMock())
+    assert driver.engine_pool is not None
+    assert driver.engine_pool.max_depth == 12


### PR DESCRIPTION
## Summary
- Add `spec.execution.engine_queue_depth` (integer ≥ 1, default **32**) to cap engine egress intents queued per kernel dispatch batch
- Wire manifest → `KernelConfig.engine_queue_depth` → `EngineWorkerPool.max_depth` in the driver
- Document the setting in `docs/manifests/execution.md` and the execution-binding schema

## Test plan
- [x] `runtime/tests/test_engine_worker_pool.py` — default, overflow, parser, driver wiring, `parse_execution` validation
- [x] `ctl/tests/test_cache_read_write_controls.py` — execution binding validation
- [x] `task verify` — full CI parity (1248+ unit tests)