### PR TITLE
fix(infra): resolve relative refs from manifest anchor only

### DIFF
--- a/ctl/src/mas/ctl/infra/__init__.py
+++ b/ctl/src/mas/ctl/infra/__init__.py
@@ -2,6 +2,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 """Infra manifest resolution — workspace bundles, user config, library entry points."""
 
-from mas.ctl.infra.resolve import InfraResolveError, resolve_infra_refs
+from mas.ctl.infra.resolve import InfraResolveError, resolution_anchor, resolve_infra_refs
 
-__all__ = ["InfraResolveError", "resolve_infra_refs"]
+__all__ = ["InfraResolveError", "resolution_anchor", "resolve_infra_refs"]

--- a/ctl/src/mas/ctl/infra/resolve.py
+++ b/ctl/src/mas/ctl/infra/resolve.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from mas.runtime.spec.schema_bindings_generated import INFRA_MIDDLEWARE_PATH_PARAM_KEYS
 from mas.runtime.spec.source import load_yaml_file, resolve_ref_with_search
 from mas.runtime.xdg import mas_infra_dir
 from mas.ctl.compose.models import ResolvedInfra
@@ -73,11 +74,13 @@ def resolve_infra_refs(
         else:
             effective = ["standard:production"]
 
+    root = resolution_anchor(anchor, ws)
+
     merged = InfraManifest(name="merged")
     errors: list[tuple[str, Exception]] = []
     for ref in effective:
         try:
-            part = _load_ref(ref, anchor=anchor or Path.cwd(), workspace=ws)
+            part = _load_ref(ref, anchor=root, workspace=ws)
             merged = _merge(merged, part)
         except Exception as exc:
             errors.append((ref, exc))
@@ -90,7 +93,7 @@ def resolve_infra_refs(
     )
     for ref in merged_interceptors:
         try:
-            part = _load_ref(ref, anchor=anchor or Path.cwd(), workspace=ws)
+            part = _load_ref(ref, anchor=root, workspace=ws)
             merged.pipeline = _merge_pipeline(merged.pipeline, part.pipeline)
         except Exception as exc:
             errors.append((ref, exc))
@@ -145,6 +148,26 @@ def _load_ref(ref: str, *, anchor: Path, workspace: WorkspaceConfig) -> InfraMan
     return _load_file(path, workspace=workspace)
 
 
+def resolution_anchor(anchor: Path | None, workspace: WorkspaceConfig) -> Path:
+    """Directory used to resolve relative infra refs (never the process CWD alone)."""
+    if anchor is not None:
+        return Path(anchor).expanduser().resolve()
+    if workspace.root:
+        return workspace.root.resolve()
+    raise InfraResolveError(
+        [
+            (
+                "<anchor>",
+                ValueError(
+                    "infra resolution requires anchor= (MAS or agent app root) or a "
+                    "workspace with a discovered root (config.yaml); relative refs are "
+                    "not resolved from the process working directory"
+                ),
+            )
+        ]
+    )
+
+
 def _resolve_ref_path(ref: str, *, anchor: Path, workspace: WorkspaceConfig) -> Path:
     if ":" in ref and "://" not in ref:
         lib_path = workspace.resolve_library_path(ref)
@@ -155,8 +178,13 @@ def _resolve_ref_path(ref: str, *, anchor: Path, workspace: WorkspaceConfig) -> 
             return bundle_path
 
     candidate = Path(ref).expanduser()
-    if candidate.is_file():
+    if candidate.is_absolute() and candidate.is_file():
         return candidate.resolve()
+
+    # Relative refs are resolved from the manifest/workspace anchor only.
+    anchored = anchor / candidate
+    if anchored.is_file():
+        return anchored.resolve()
 
     return resolve_ref_with_search(
         ref,
@@ -277,13 +305,14 @@ def _load_file(
         applies = spec.get("applies_to") or ["LLM_CALL"]
         if isinstance(applies, str):
             applies = [applies]
+        params = _resolve_pipeline_param_paths(dict(spec.get("params") or {}), anchor=path.parent)
         return InfraManifest(
             name=str((data.get("metadata") or {}).get("name", path.stem)),
             kind=kind,
             pipeline=[
                 {
                     "middleware": spec.get("middleware") or path.stem.replace("-", "_"),
-                    "params": dict(spec.get("params") or {}),
+                    "params": params,
                     "applies_to": list(applies),
                 }
             ],
@@ -369,6 +398,19 @@ def _merge_many(parts: list[InfraManifest]) -> InfraManifest:
     )
 
 
+def _resolve_pipeline_param_paths(params: dict[str, Any], *, anchor: Path) -> dict[str, Any]:
+    out = dict(params)
+    for key in INFRA_MIDDLEWARE_PATH_PARAM_KEYS:
+        value = out.get(key)
+        if not isinstance(value, str):
+            continue
+        candidate = Path(value).expanduser()
+        if not candidate.is_absolute():
+            candidate = (anchor / candidate).resolve()
+        out[key] = str(candidate)
+    return out
+
+
 def _resolve_pipeline_entry(
     entry: Any,
     *,
@@ -379,13 +421,19 @@ def _resolve_pipeline_entry(
         child_path = _resolve_ref_path(entry, anchor=anchor, workspace=workspace)
         loaded = _load_file(child_path, workspace=workspace)
         if loaded.pipeline:
-            return dict(loaded.pipeline[0])
+            step = dict(loaded.pipeline[0])
+            step["params"] = _resolve_pipeline_param_paths(
+                dict(step.get("params") or {}),
+                anchor=child_path.parent,
+            )
+            return step
         return {"middleware": entry.split(":")[-1].replace("-", "_"), "params": {}}
     if isinstance(entry, dict):
         if "ref" in entry:
             return _resolve_pipeline_entry(str(entry["ref"]), anchor=anchor, workspace=workspace)
         mid = entry.get("middleware") or entry.get("id")
-        return {"middleware": mid, "params": dict(entry.get("params") or {})}
+        params = _resolve_pipeline_param_paths(dict(entry.get("params") or {}), anchor=anchor)
+        return {"middleware": mid, "params": params}
     raise ValueError(f"invalid pipeline entry: {entry!r}")
 
 

--- a/ctl/src/mas/ctl/session/bootstrap.py
+++ b/ctl/src/mas/ctl/session/bootstrap.py
@@ -18,6 +18,7 @@ from mas.ctl.adapters.memory_seed import (
     seeds_from_manifest,
 )
 from mas.ctl.compose.models import ResolvedInfra
+from mas.ctl.infra.resolve import resolution_anchor
 from mas.ctl.session.engine_factory import build_engine
 from mas.ctl.validate import validate_file, validation_enabled
 from mas.ctl.workspace.config import WorkspaceConfig
@@ -132,7 +133,7 @@ def instantiate_runtime(
             agency = mas_spec.get("agency") if isinstance(mas_spec, dict) else None
             if isinstance(agency, dict) and agency.get("agents"):
                 spec["agency"] = {"agents": list(agency.get("agents") or [])}
-    ws = options.workspace or WorkspaceConfig.load(options.manifest_dir or Path.cwd())
+    ws = options.workspace or WorkspaceConfig.load(options.manifest_dir)
     # Pre-parse spec to derive kernel config once; pass to build_engine to avoid double-parsing.
     from mas.runtime.spec.parser import parse_agent_spec
 
@@ -143,7 +144,7 @@ def instantiate_runtime(
         options.resolved_infra,
         pattern_plugin_id=options.pattern_plugin_id,
         workspace_default_model=ws.default_model,
-        anchor=options.manifest_dir or Path.cwd(),
+        anchor=resolution_anchor(options.manifest_dir, ws),
         workspace=ws,
         kernel_config=_kernel_cfg,
         cache_read_override=options.cache_read_override,

--- a/ctl/src/mas/ctl/session/engine_factory.py
+++ b/ctl/src/mas/ctl/session/engine_factory.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from mas.ctl.compose.models import ResolvedInfra
-from mas.ctl.infra.resolve import resolve_infra_refs
+from mas.ctl.infra.resolve import resolution_anchor, resolve_infra_refs
 from mas.ctl.infra.resolve import InfraResolveError
 from mas.ctl.infra.resolve import api_key_for_infra
 from mas.ctl.session.manifest_config import engine_use_tool_loop, kernel_config_from_manifest  # kernel_config_from_manifest: deprecated; prefer RuntimeInstance.from_spec()
@@ -177,10 +177,11 @@ def build_engine(
     # Use pre-parsed kernel config if provided (spec-aware path); fall back to manifest parsing.
     kernel_cfg = kernel_config if kernel_config is not None else kernel_config_from_manifest(manifest, pattern_plugin_id=pid)
     tool_loop = engine_use_tool_loop(manifest, kernel_cfg)
-    ref_anchor = anchor or Path.cwd()
+    ws = workspace or WorkspaceConfig.load(anchor)
+    ref_anchor = resolution_anchor(anchor, ws)
 
     resolved = _resolve_infra_for_engine(
-        manifest, infra, anchor=ref_anchor, workspace=workspace
+        manifest, infra, anchor=ref_anchor, workspace=ws
     )
     llm_proxy = dict(resolved.llm_proxy or {})
     mock = is_mock_mode(manifest, resolved) or bool(llm_proxy.get("mock"))

--- a/ctl/tests/test_engine_factory.py
+++ b/ctl/tests/test_engine_factory.py
@@ -35,6 +35,19 @@ def test_build_engine_errors_without_infra_or_mock(monkeypatch, tmp_path):
         )
 
 
+def test_build_engine_resolves_infra_anchor_from_workspace_when_omitted(monkeypatch, tmp_path):
+    from mas.ctl.workspace.config import UserConfig, WorkspaceConfig
+
+    ws = WorkspaceConfig({}, tmp_path)
+    monkeypatch.setattr(WorkspaceConfig, "load", lambda *a, **k: ws)
+    monkeypatch.setattr(UserConfig, "load", lambda *a, **k: UserConfig({}))
+    ctx = AutoCtxAssembler()
+    manifest = {"spec": {"execution": {"mocking": {"enabled": True}}}}
+
+    sel = build_engine(ctx, manifest, None, workspace=ws)
+    assert sel.mode == "mock"
+
+
 def test_build_engine_mock_mode_from_execution_flag(monkeypatch, tmp_path):
     from mas.ctl.infra.resolve import resolve_infra_refs
     from mas.ctl.workspace.config import UserConfig, WorkspaceConfig

--- a/ctl/tests/test_infra_entries.py
+++ b/ctl/tests/test_infra_entries.py
@@ -9,7 +9,12 @@ import pytest
 import yaml
 
 from mas.ctl.infra.pipeline_chain import BidirectionalInfraPipeline, InfraChainContext
-from mas.ctl.infra.resolve import _load_file, bidirectional_pipeline_for, resolve_infra_refs
+from mas.ctl.infra.resolve import (
+    InfraResolveError,
+    _load_file,
+    bidirectional_pipeline_for,
+    resolve_infra_refs,
+)
 from mas.ctl.workspace.config import WorkspaceConfig
 
 
@@ -70,6 +75,133 @@ def test_infra_bundle_entries_loads_llm_proxy_cached(tmp_path: Path, monkeypatch
     pipeline = merged.pipeline or []
     assert any(step.get("middleware") == "llm_cache" for step in pipeline)
     assert merged.proxy.api_base or merged.models.default_llm is not None or merged.name
+
+
+def test_relative_llm_cache_path_is_resolved_from_infra_manifest_dir(tmp_path: Path):
+    infra_dir = tmp_path / "infra"
+    infra_dir.mkdir()
+    (infra_dir / "llm-cache-write.yaml").write_text(
+        """
+apiVersion: infra/v1
+kind: InfraMiddleware
+metadata:
+  name: llm-cache-write
+spec:
+  middleware: llm_cache
+  applies_to: [LLM_CALL]
+  params:
+    allow_read: true
+    allow_write: true
+    cache_path: .cache/demo-cache.json
+""".strip(),
+        encoding="utf-8",
+    )
+
+    infra = resolve_infra_refs(["infra/llm-cache-write.yaml"], anchor=tmp_path)
+    pipeline = infra.llm_proxy.get("pipeline") or []
+    assert pipeline
+    params = pipeline[0]["params"]
+    assert Path(params["cache_path"]).is_absolute()
+    assert Path(params["cache_path"]) == (infra_dir / ".cache" / "demo-cache.json").resolve()
+
+
+def test_relative_ref_resolves_from_anchor_not_process_cwd(tmp_path: Path, monkeypatch):
+    """A same-named file in the process CWD must never shadow the anchor-relative ref."""
+    project_dir = tmp_path / "anchor-project"
+    infra_dir = project_dir / "infra"
+    infra_dir.mkdir(parents=True)
+    (infra_dir / "llm-cache-write.yaml").write_text(
+        """
+apiVersion: infra/v1
+kind: InfraMiddleware
+metadata:
+  name: llm-cache-write
+spec:
+  middleware: llm_cache
+  applies_to: [LLM_CALL]
+  params:
+    cache_path: .cache/from-anchor.json
+""".strip(),
+        encoding="utf-8",
+    )
+
+    decoy_dir = tmp_path / "decoy-cwd"
+    decoy_infra_dir = decoy_dir / "infra"
+    decoy_infra_dir.mkdir(parents=True)
+    (decoy_infra_dir / "llm-cache-write.yaml").write_text(
+        """
+apiVersion: infra/v1
+kind: InfraMiddleware
+metadata:
+  name: llm-cache-write
+spec:
+  middleware: llm_cache
+  applies_to: [LLM_CALL]
+  params:
+    cache_path: .cache/from-decoy-cwd.json
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(decoy_dir)
+    infra = resolve_infra_refs(["infra/llm-cache-write.yaml"], anchor=project_dir)
+    pipeline = infra.llm_proxy.get("pipeline") or []
+    assert pipeline
+    cache_path = Path(pipeline[0]["params"]["cache_path"])
+    assert cache_path == (infra_dir / ".cache" / "from-anchor.json").resolve()
+    assert "from-decoy-cwd" not in cache_path.as_posix()
+
+
+def test_relative_ref_not_loaded_from_process_cwd_only(tmp_path: Path, monkeypatch):
+    """Process CWD must not satisfy a ref that is missing under anchor."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    decoy = tmp_path / "decoy"
+    decoy_infra = decoy / "infra"
+    decoy_infra.mkdir(parents=True)
+    (decoy_infra / "missing-at-anchor.yaml").write_text(
+        """
+apiVersion: infra/v1
+kind: InfraMiddleware
+metadata:
+  name: decoy
+spec:
+  middleware: llm_cache
+  applies_to: [LLM_CALL]
+  params:
+    cache_path: .cache/decoy.json
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(decoy)
+    with pytest.raises((FileNotFoundError, InfraResolveError)):
+        resolve_infra_refs(["infra/missing-at-anchor.yaml"], anchor=project_dir)
+
+
+def test_library_samples_llm_cache_write_resolves_cache_path():
+    repo = Path(__file__).resolve().parents[2]
+    manifest = repo / "library-samples" / "infra" / "llm-cache-write.yaml"
+    if not manifest.is_file():
+        pytest.skip("library-samples/infra/llm-cache-write.yaml not in workspace")
+    infra = resolve_infra_refs(["library-samples/infra/llm-cache-write.yaml"], anchor=repo)
+    pipeline = infra.llm_proxy.get("pipeline") or []
+    assert pipeline and pipeline[0].get("middleware") == "llm_cache"
+    cache_path = Path(pipeline[0]["params"]["cache_path"])
+    expected = (repo / "library-samples" / "infra" / "cache" / "demo.llm-cache.json").resolve()
+    assert cache_path == expected
+
+
+def test_resolve_infra_uses_workspace_root_when_anchor_omitted():
+    """Library/eval paths that pass workspace= only still resolve scheme refs."""
+    repo = Path(__file__).resolve().parents[2]
+    sample = repo / "library-samples" / "sample-workspace"
+    if not (sample / "config.yaml").is_file():
+        pytest.skip("library-samples/sample-workspace/config.yaml not in workspace")
+    ws = WorkspaceConfig.load(sample)
+    assert ws.found and ws.root
+    infra = resolve_infra_refs(["standard:mock-llm"], workspace=ws)
+    assert infra.refs == ["standard:mock-llm"]
+    assert infra.llm_proxy.get("api_key_env")
 
 
 def test_workspace_infra_refs_resolve_from_subdirectory():

--- a/docs/manifests/infra.md
+++ b/docs/manifests/infra.md
@@ -53,6 +53,26 @@ Referenced from MAS `spec.infra_refs`, workspace, or CLI `--infra-ref`.
 
 ---
 
+## Relative refs and anchor
+
+Filesystem infra refs (for example `infra/llm-cache-write.yaml`) resolve **only**
+relative to:
+
+1. The explicit **`anchor=`** passed to `resolve_infra_refs` (typically the MAS
+   or agent app root — parent of `mas.yaml` / `agent.yaml`), or
+2. The discovered **workspace root** when `anchor` is omitted and
+   `config.yaml` was found.
+
+The process **working directory is not used** to locate infra YAML files. That
+keeps `spec.infra_refs` tied to the application that declared them when
+`mas-ctl`, benchmarks, or tests run from another directory.
+
+Relative `cache_path` / `path` values on `InfraMiddleware` `spec.params` are
+made absolute at load time relative to the **directory containing that infra
+YAML file** (not CWD). See [LLM cache reference](../references/llm-cache.md).
+
+---
+
 ## Separation from Flavour
 
 | Infra | Flavour |

--- a/docs/manifests/llm-cache.md
+++ b/docs/manifests/llm-cache.md
@@ -55,7 +55,7 @@ and pruning — see [Known limitations](../references/llm-cache.md#known-limitat
 
 | Manifest | Ref / path | Purpose |
 | --- | --- | --- |
-| Write | `library-samples/infra/llm-cache-write.yaml` | `library-samples/infra/cache/demo.llm-cache.json` |
+| Write | `library-samples/infra/llm-cache-write.yaml` | `cache/demo.llm-cache.json` (resolved under that infra dir) |
 | Replay | `library-samples/infra/llm-cache-replay.yaml` | Strict replay; same `cache_path` |
 | Read+write | `standard:llm-cache` | XDG default; both read and write |
 | Provider + cache | `standard:llm-proxy-cached` | `InfraBundle` (cache + OpenAI) |
@@ -85,7 +85,7 @@ spec:
     allow_read: false
     allow_write: true
     raise_on_miss: false
-    cache_path: library-samples/infra/cache/demo.llm-cache.json
+    cache_path: cache/demo.llm-cache.json
 ```
 
 `allow_read: false` — always call the provider on a miss; still write responses.
@@ -112,7 +112,7 @@ spec:
     allow_read: true
     allow_write: false
     raise_on_miss: true
-    cache_path: library-samples/infra/cache/demo.llm-cache.json
+    cache_path: cache/demo.llm-cache.json
 ```
 
 On a hit the provider is not called. On a miss, `raise_on_miss: true` errors

--- a/docs/references/llm-cache.md
+++ b/docs/references/llm-cache.md
@@ -145,6 +145,11 @@ $XDG_CACHE_HOME/mas/llm_cache.json
 (`UserConfig.cache_dir / "llm_cache.json"`). Explicit `cache_path` in the
 manifest is never overwritten.
 
+Relative `cache_path` / `path` strings are resolved to absolute paths at infra
+load time against the directory that contains the middleware YAML file. Infra
+file refs themselves resolve from the MAS/agent **anchor** or workspace root,
+not from the process working directory (see [infra.md](../manifests/infra.md)).
+
 `MAS_LLM_CACHE` env var applies to the **built-in** engine cache only — not
 middleware `params.cache_path`.
 
@@ -246,8 +251,8 @@ It is ignored on read; use it to identify entries when pruning manually.
 
 | Approach | Example | Notes |
 | --- | --- | --- |
-| Next to agent | `.cache/tutorial.llm-cache.json` | Relative to process CWD when file is opened |
-| Repo example | `library-samples/infra/cache/demo.llm-cache.json` | Run from repository root |
+| Next to infra YAML | `.cache/tutorial.llm-cache.json` | Resolved relative to the middleware manifest directory |
+| Repo example | `cache/demo.llm-cache.json` in infra YAML | Resolves to `library-samples/infra/cache/demo.llm-cache.json` |
 | XDG default | `null` or omit | `standard:llm-cache-*` refs |
 | Env `MAS_LLM_CACHE` | — | Built-in engine cache only |
 
@@ -261,7 +266,7 @@ Delete the JSON file to invalidate all entries. Format: `{ "<sha256-hex>": "<tex
 | --- | --- | --- | --- | --- |
 | `standard:llm-cache` | `true` | `true` | `false` | XDG |
 | `standard:llm-proxy-cached` | (bundle) | — | — | cache + `standard:openai` |
-| `library-samples/infra/llm-cache-write.yaml` | `false` | `true` | `false` | `library-samples/infra/cache/demo.llm-cache.json` |
+| `library-samples/infra/llm-cache-write.yaml` | `false` | `true` | `false` | `cache/demo.llm-cache.json` (under infra dir) |
 | `library-samples/infra/llm-cache-replay.yaml` | `true` | `false` | `true` | same |
 
 ---

--- a/docs/schemas/runtime/fragments/infra-middleware-params.schema.yaml
+++ b/docs/schemas/runtime/fragments/infra-middleware-params.schema.yaml
@@ -19,8 +19,10 @@ properties:
     type: boolean
   cache_path:
     type: [string, "null"]
+    x-filesystem-path: true
   path:
     type: string
+    x-filesystem-path: true
   rate:
     type: number
     minimum: 0

--- a/library-samples/infra/llm-cache-replay.yaml
+++ b/library-samples/infra/llm-cache-replay.yaml
@@ -18,4 +18,4 @@ spec:
     allow_read: true
     allow_write: false
     raise_on_miss: true
-    cache_path: library-samples/infra/cache/demo.llm-cache.json
+    cache_path: cache/demo.llm-cache.json

--- a/library-samples/infra/llm-cache-write.yaml
+++ b/library-samples/infra/llm-cache-write.yaml
@@ -17,4 +17,4 @@ spec:
     allow_read: false
     allow_write: true
     raise_on_miss: false
-    cache_path: library-samples/infra/cache/demo.llm-cache.json
+    cache_path: cache/demo.llm-cache.json

--- a/runtime/src/mas/runtime/spec/schema_bindings_generated.py
+++ b/runtime/src/mas/runtime/spec/schema_bindings_generated.py
@@ -89,3 +89,10 @@ CONTEXT_MANAGER_STRATEGY_PARAM_KEYS = frozenset(
     }
 )
 
+INFRA_MIDDLEWARE_PATH_PARAM_KEYS = frozenset(
+    {
+    'cache_path',
+    'path',
+    }
+)
+

--- a/runtime/tests/test_schema_artifacts.py
+++ b/runtime/tests/test_schema_artifacts.py
@@ -22,6 +22,12 @@ def test_schema_artifacts_up_to_date():
     assert result.returncode == 0, result.stderr or result.stdout
 
 
+def test_infra_middleware_path_param_keys_match_schema():
+    from mas.runtime.spec.schema_bindings_generated import INFRA_MIDDLEWARE_PATH_PARAM_KEYS
+
+    assert INFRA_MIDDLEWARE_PATH_PARAM_KEYS == frozenset({"cache_path", "path"})
+
+
 def test_cm_factory_strips_only_assembly_param_keys():
     from mas.runtime.contracts.cm_factory import CMFactory
     from mas.runtime.spec.schema_bindings_generated import (

--- a/scripts/gen_schema_artifacts.py
+++ b/scripts/gen_schema_artifacts.py
@@ -62,6 +62,14 @@ def _property_keys(schema: dict[str, Any], base: Path) -> frozenset[str]:
     return frozenset(_merged_properties(schema, base).keys())
 
 
+def _filesystem_path_param_keys(schema: dict[str, Any], base: Path) -> frozenset[str]:
+    keys: list[str] = []
+    for key, prop in _merged_properties(schema, base).items():
+        if isinstance(prop, dict) and prop.get("x-filesystem-path"):
+            keys.append(key)
+    return frozenset(keys)
+
+
 def _property_defaults(schema: dict[str, Any], base: Path) -> dict[str, Any]:
     defaults: dict[str, Any] = {}
     for key, prop in _merged_properties(schema, base).items():
@@ -101,6 +109,7 @@ def _render_bindings(agent: dict[str, Any]) -> str:
     control = _load(_FRAGMENTS / "control-binding.schema.yaml")
     assembly = _load(_FRAGMENTS / "context-manager-assembly-params.schema.yaml")
     strategy = _load(_FRAGMENTS / "context-manager-strategy-params.schema.yaml")
+    infra_mw = _load(_FRAGMENTS / "infra-middleware-params.schema.yaml")
 
     lines = [
         "#  Copyright (c) 2026 Cisco Systems, Inc. and its affiliates",
@@ -125,6 +134,10 @@ def _render_bindings(agent: dict[str, Any]) -> str:
         (
             "CONTEXT_MANAGER_STRATEGY_PARAM_KEYS",
             _property_keys(strategy, _FRAGMENTS),
+        ),
+        (
+            "INFRA_MIDDLEWARE_PATH_PARAM_KEYS",
+            _filesystem_path_param_keys(infra_mw, _FRAGMENTS),
         ),
     ]
     for name, keys in chunks:


### PR DESCRIPTION
Relative infra YAML refs and middleware cache_path/path params must not depend
on the process working directory. Resolve file refs from explicit anchor
(MAS/agent app root) or discovered workspace root; no CWD fallback.

Export resolution_anchor for engine bootstrap; build_engine uses workspace
root when anchor is omitted. INFRA_MIDDLEWARE_PATH_PARAM_KEYS generated from
schema (x-filesystem-path). Normalize nested middleware pipeline params.

Fix library-samples cache_path to be relative to infra YAML dir; document and
test end-to-end resolution of library-samples/infra/llm-cache-write.yaml.
